### PR TITLE
fix: harden invite/auth flow and align types with live schema

### DIFF
--- a/apps/web/src/hooks/useAuditStateMachine.ts
+++ b/apps/web/src/hooks/useAuditStateMachine.ts
@@ -102,14 +102,6 @@ export function useAuditStateMachine(
         permissions.warningType = 'info'
         permissions.nextAction = null
         break
-
-      case AuditStatus.FINALIZED:
-        permissions.canEdit = false
-        permissions.canViewOnly = true
-        permissions.showWarning = 'This audit has been finalized and locked. No changes can be made.'
-        permissions.warningType = 'info'
-        permissions.nextAction = null
-        break
     }
   }
 
@@ -126,7 +118,7 @@ export function useAuditStateMachine(
 
       case AuditStatus.SUBMITTED:
         permissions.canViewOnly = true
-        permissions.canEdit = false // Managers review, don't edit
+        permissions.canEdit = false
         permissions.nextAction = 'Review this audit and approve or reject'
         permissions.warningType = 'info'
         break
@@ -142,30 +134,16 @@ export function useAuditStateMachine(
         permissions.showWarning = 'You approved this audit.'
         permissions.warningType = 'info'
         break
-
-      case AuditStatus.FINALIZED:
-        permissions.canViewOnly = true
-        permissions.showWarning = 'This audit has been finalized.'
-        permissions.warningType = 'info'
-        break
     }
   }
 
   // ADMIN/SUPER_ADMIN permissions - can do anything (but should respect workflow)
   if (userRole === UserRole.ADMIN || userRole === UserRole.SUPER_ADMIN) {
-    // Admins can view everything
     permissions.canViewOnly = true
-    
-    // Admins can override in special cases (but UI should make this clear)
+
     if (currentStatus === AuditStatus.DRAFT || currentStatus === AuditStatus.IN_PROGRESS) {
       permissions.canEdit = true
       permissions.canDelete = true
-    }
-    
-    if (currentStatus === AuditStatus.FINALIZED) {
-      permissions.canReopen = true
-      permissions.showWarning = 'This audit is finalized. Only admins can reopen it.'
-      permissions.warningType = 'warning'
     }
   }
 
@@ -183,7 +161,6 @@ function getStatusLabel(status: AuditStatus): string {
     [AuditStatus.SUBMITTED]: 'Submitted for Review',
     [AuditStatus.REJECTED]: 'Rejected - Needs Revision',
     [AuditStatus.APPROVED]: 'Approved',
-    [AuditStatus.FINALIZED]: 'Finalized',
   }
   
   return labels[status] || status

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -45,48 +45,6 @@ interface AuthState {
   isManualSignOut: boolean
 }
 
-// Mock users for different roles
-const mockUsers: Record<UserRole, User> = {
-  [UserRole.AUDITOR]: {
-    id: 'user-1',
-    name: 'John Auditor',
-    email: 'auditor@trakr.com',
-    role: UserRole.AUDITOR,
-    orgId: 'org-1',
-    branchId: 'branch-1',
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
-  },
-  [UserRole.BRANCH_MANAGER]: {
-    id: 'user-2',
-    name: 'Jane Manager',
-    email: 'branchmanager@trakr.com',
-    role: UserRole.BRANCH_MANAGER,
-    orgId: 'org-1',
-    branchId: 'branch-1',
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
-  },
-  [UserRole.ADMIN]: {
-    id: 'user-3',
-    name: 'Admin User',
-    email: 'admin@trakr.com',
-    role: UserRole.ADMIN,
-    orgId: 'org-1',
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
-  },
-  [UserRole.SUPER_ADMIN]: {
-    id: 'user-4',
-    name: 'Super Admin',
-    email: 'superadmin@trakr.com',
-    role: UserRole.SUPER_ADMIN,
-    orgId: 'org-1',
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
-  },
-}
-
 export const useAuthStore = create<AuthState>()(
   persist(
     (set, _get) => ({
@@ -192,18 +150,9 @@ export const useAuthStore = create<AuthState>()(
           
           set({ user, isAuthenticated: true, isLoading: false })
         } catch (e) {
-          // Last-resort fallback to local mock identity (development only)
-          if (import.meta.env.DEV) {
-            const fallback = mockUsers[role]
-            preloadDashboardChunk(fallback.role)
-            set({ user: fallback, isAuthenticated: true, isLoading: false })
-            logger.error('Role-based login failed, using mock fallback (DEV only)', e, { context: 'AuthStore' })
-          } else {
-            // In production, fail loudly instead of masking the issue
-            set({ isLoading: false })
-            logger.error('Role-based login failed in production', e, { context: 'AuthStore' })
-            throw e
-          }
+          set({ isLoading: false })
+          logger.error('Role-based login failed', e, { context: 'AuthStore' })
+          throw e
         }
       },
 
@@ -235,7 +184,7 @@ export const useAuthStore = create<AuthState>()(
               appUser = allUsers.value.find(u => (u.email || '').toLowerCase() === email.toLowerCase()) || null
             }
           } catch (parallelError) {
-            console.warn('[Auth] Parallel lookup failed, trying sequential', parallelError)
+            logger.warn('Parallel user lookup failed, trying sequential', { context: 'auth', data: parallelError })
             // Fallback to sequential lookup
             try {
               appUser = await api.getUserById(authUser.id)

--- a/apps/web/src/utils/sentry.ts
+++ b/apps/web/src/utils/sentry.ts
@@ -31,9 +31,9 @@ export function initSentry() {
     environment: ENVIRONMENT,
     release: RELEASE,
 
-    // Send default PII data (IP address, user agent) for better debugging
-    // Note: User context (email, ID) is already sent separately
-    sendDefaultPii: true,
+    // Do not send default PII (IP address, user agent) — user context is set
+    // explicitly via setSentryUser() after login, which is sufficient for debugging
+    sendDefaultPii: false,
 
     // Performance Monitoring
     integrations: [

--- a/apps/web/src/utils/supabaseApi.ts
+++ b/apps/web/src/utils/supabaseApi.ts
@@ -46,7 +46,8 @@ const mapUser = (row: Tables<'users'>): User => ({
   name: (row as any).full_name || displayNameFromEmail(row.email),
   email: row.email,
   role: mapUserRole(row.role as Enums<'user_role'>),
-  orgId: row.org_id,
+  // users.org_id is nullable in the DB; '' keeps falsy semantics for org checks
+  orgId: row.org_id ?? '',
   branchId: row.branch_id || undefined,
   signatureUrl: (row as any).signature_url || undefined,
   avatarUrl: (row as any).avatar_url || undefined,
@@ -896,8 +897,8 @@ export const supabaseApi = {
       if (upErr) throw upErr
       const { data: urlData } = supabase.storage.from('audit-photos').getPublicUrl(path)
       publicUrl = urlData.publicUrl
-    } catch {
-      // Fallback: keep original URL if upload fails (dev)
+    } catch (uploadErr) {
+      throw new Error(`Photo upload failed: ${uploadErr instanceof Error ? uploadErr.message : 'Storage error'}`)
     }
     const now = new Date().toISOString()
     const { data, error } = await supabase
@@ -1732,34 +1733,6 @@ export const supabaseApi = {
     if (error) throw error
     return mapUser(data as any)
   },
-  async createUser(payload: {
-    id: string
-    email: string
-    name: string
-    role: string
-    orgId: string | null
-    isActive: boolean
-  }): Promise<User> {
-    const supabase = await getSupabase()
-    const { data, error } = await supabase
-      .from('users')
-      .insert({
-        id: payload.id,
-        email: payload.email,
-        full_name: payload.name,
-        role: payload.role,
-        org_id: payload.orgId,
-        is_active: payload.isActive,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString()
-      })
-      .select('*')
-      .single()
-    
-    if (error) throw error
-    return mapUser(data as Tables<'users'>)
-  },
-
   async updateUser(id: string, updates: Partial<{ name: string; email: string; role: UserRole; isActive: boolean; org_id: string; phone: string }>) {
     const supabase = await getSupabase()
 
@@ -1911,22 +1884,11 @@ export const supabaseApi = {
 
   async resendInvitation(userId: string): Promise<void> {
     const supabase = await getSupabase()
-    
-    // Get user details
-    const { data: user } = await supabase.from('users').select('email, full_name').eq('id', userId).single()
-    if (!user) throw new Error('User not found')
-    
-    // Note: Actual email sending requires either:
-    // 1. Supabase Auth Admin API to resend magic link
-    // 2. Custom email service (SendGrid, Resend, etc.)
-    // 3. Edge Function to handle invitation emails
-    
-    // For now, we'll log this action (can be picked up by monitoring)
-    logger.info(`Resend invitation: ${user.email}`, { context: 'SupabaseAPI' })
-    
-    // In production, implement one of:
-    // await supabase.auth.admin.generateLink({ type: 'magiclink', email: user.email })
-    // await sendInvitationEmail(user.email, user.full_name)
+    const { data, error } = await supabase.functions.invoke('invite-user-resend', {
+      body: { userId },
+    })
+    if (error) throw new Error(error.message || 'Failed to resend invitation')
+    if (data?.error) throw new Error(data.error)
   },
 
   // ===================================

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -35,7 +35,6 @@
     "src/tests/**"
   ],
   "references": [
-    { "path": "./tsconfig.node.json" },
-    { "path": "./tsconfig.test.json" }
+    { "path": "./tsconfig.node.json" }
   ]
 }

--- a/packages/shared/src/db/types.ts
+++ b/packages/shared/src/db/types.ts
@@ -7,6 +7,8 @@ export type Json =
   | Json[]
 
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: "13.0.5"
   }
@@ -15,32 +17,38 @@ export type Database = {
       activity_logs: {
         Row: {
           action: string
+          branch_id: string | null
           created_at: string
           details: string | null
           entity_id: string | null
           entity_type: string | null
           id: string
           org_id: string
+          survey_id: string | null
           user_id: string | null
         }
         Insert: {
           action: string
+          branch_id?: string | null
           created_at?: string
           details?: string | null
           entity_id?: string | null
           entity_type?: string | null
           id?: string
           org_id: string
+          survey_id?: string | null
           user_id?: string | null
         }
         Update: {
           action?: string
+          branch_id?: string | null
           created_at?: string
           details?: string | null
           entity_id?: string | null
           entity_type?: string | null
           id?: string
           org_id?: string
+          survey_id?: string | null
           user_id?: string | null
         }
         Relationships: [
@@ -60,50 +68,20 @@ export type Database = {
           },
         ]
       }
-      data_access_audit: {
+      app_config: {
         Row: {
-          id: string
-          org_id: string
-          user_id: string | null
-          action: string
-          reason: string | null
-          export_scope: Json | null
-          created_at: string
+          key: string
+          value: string
         }
         Insert: {
-          id?: string
-          org_id: string
-          user_id?: string | null
-          action?: string
-          reason?: string | null
-          export_scope?: Json | null
-          created_at?: string
+          key: string
+          value: string
         }
         Update: {
-          id?: string
-          org_id?: string
-          user_id?: string | null
-          action?: string
-          reason?: string | null
-          export_scope?: Json | null
-          created_at?: string
+          key?: string
+          value?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "data_access_audit_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "data_access_audit_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          }
-        ]
+        Relationships: []
       }
       audit_photos: {
         Row: {
@@ -145,6 +123,51 @@ export type Database = {
             foreignKeyName: "audit_photos_uploaded_by_fkey"
             columns: ["uploaded_by"]
             isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      auditor_assignments: {
+        Row: {
+          branch_ids: string[] | null
+          created_at: string | null
+          id: string
+          org_id: string | null
+          updated_at: string | null
+          user_id: string
+          zone_ids: string[] | null
+        }
+        Insert: {
+          branch_ids?: string[] | null
+          created_at?: string | null
+          id?: string
+          org_id?: string | null
+          updated_at?: string | null
+          user_id: string
+          zone_ids?: string[] | null
+        }
+        Update: {
+          branch_ids?: string[] | null
+          created_at?: string | null
+          id?: string
+          org_id?: string | null
+          updated_at?: string | null
+          user_id?: string
+          zone_ids?: string[] | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "auditor_assignments_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "auditor_assignments_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
             referencedRelation: "users"
             referencedColumns: ["id"]
           },
@@ -223,12 +246,18 @@ export type Database = {
           archived_at: string | null
           assigned_to: string | null
           branch_id: string
+          completed_at: string | null
+          completed_by: string | null
           created_at: string
+          created_by: string | null
+          created_origin: string | null
           due_at: string
           id: string
           is_archived: boolean
           na_reasons: Json
           org_id: string
+          override_notes: Json
+          override_scores: Json
           period_end: string
           period_start: string
           rejected_at: string | null
@@ -236,6 +265,8 @@ export type Database = {
           rejection_note: string | null
           responses: Json
           section_comments: Json
+          started_at: string | null
+          started_by: string | null
           status: Database["public"]["Enums"]["audit_status"]
           submitted_at: string | null
           submitted_by: string | null
@@ -253,12 +284,18 @@ export type Database = {
           archived_at?: string | null
           assigned_to?: string | null
           branch_id: string
+          completed_at?: string | null
+          completed_by?: string | null
           created_at?: string
+          created_by?: string | null
+          created_origin?: string | null
           due_at: string
           id?: string
           is_archived?: boolean
           na_reasons?: Json
           org_id: string
+          override_notes?: Json
+          override_scores?: Json
           period_end: string
           period_start: string
           rejected_at?: string | null
@@ -266,6 +303,8 @@ export type Database = {
           rejection_note?: string | null
           responses?: Json
           section_comments?: Json
+          started_at?: string | null
+          started_by?: string | null
           status?: Database["public"]["Enums"]["audit_status"]
           submitted_at?: string | null
           submitted_by?: string | null
@@ -283,12 +322,18 @@ export type Database = {
           archived_at?: string | null
           assigned_to?: string | null
           branch_id?: string
+          completed_at?: string | null
+          completed_by?: string | null
           created_at?: string
+          created_by?: string | null
+          created_origin?: string | null
           due_at?: string
           id?: string
           is_archived?: boolean
           na_reasons?: Json
           org_id?: string
+          override_notes?: Json
+          override_scores?: Json
           period_end?: string
           period_start?: string
           rejected_at?: string | null
@@ -296,6 +341,8 @@ export type Database = {
           rejection_note?: string | null
           responses?: Json
           section_comments?: Json
+          started_at?: string | null
+          started_by?: string | null
           status?: Database["public"]["Enums"]["audit_status"]
           submitted_at?: string | null
           submitted_by?: string | null
@@ -355,11 +402,64 @@ export type Database = {
           },
         ]
       }
+      branch_manager_assignments: {
+        Row: {
+          assigned_at: string | null
+          assigned_by: string | null
+          branch_id: string
+          created_at: string | null
+          id: string
+          manager_id: string
+          updated_at: string | null
+        }
+        Insert: {
+          assigned_at?: string | null
+          assigned_by?: string | null
+          branch_id: string
+          created_at?: string | null
+          id?: string
+          manager_id: string
+          updated_at?: string | null
+        }
+        Update: {
+          assigned_at?: string | null
+          assigned_by?: string | null
+          branch_id?: string
+          created_at?: string | null
+          id?: string
+          manager_id?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "branch_manager_assignments_assigned_by_fkey"
+            columns: ["assigned_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "branch_manager_assignments_branch_id_fkey"
+            columns: ["branch_id"]
+            isOneToOne: false
+            referencedRelation: "branches"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "branch_manager_assignments_manager_id_fkey"
+            columns: ["manager_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       branches: {
         Row: {
           address: string | null
           created_at: string
           id: string
+          is_active: boolean
           manager_id: string | null
           name: string
           org_id: string
@@ -369,6 +469,7 @@ export type Database = {
           address?: string | null
           created_at?: string
           id?: string
+          is_active?: boolean
           manager_id?: string | null
           name: string
           org_id: string
@@ -378,6 +479,7 @@ export type Database = {
           address?: string | null
           created_at?: string
           id?: string
+          is_active?: boolean
           manager_id?: string | null
           name?: string
           org_id?: string
@@ -400,79 +502,136 @@ export type Database = {
           },
         ]
       }
-      organizations: {
+      data_access_audit: {
         Row: {
+          action: string
           created_at: string
+          export_scope: Json | null
           id: string
-          name: string
-          time_zone: string
-          updated_at: string
-          week_starts_on: number
-          gating_policy: string
+          org_id: string
+          reason: string | null
+          user_id: string | null
         }
         Insert: {
+          action?: string
           created_at?: string
+          export_scope?: Json | null
           id?: string
-          name: string
-          time_zone?: string
-          updated_at?: string
-          week_starts_on?: number
-          gating_policy?: string
+          org_id: string
+          reason?: string | null
+          user_id?: string | null
         }
         Update: {
+          action?: string
           created_at?: string
+          export_scope?: Json | null
           id?: string
-          name?: string
-          time_zone?: string
-          updated_at?: string
-          week_starts_on?: number
-          gating_policy?: string
-        }
-        Relationships: []
-      }
-      surveys: {
-        Row: {
-          created_at: string
-          description: string | null
-          frequency: Database["public"]["Enums"]["audit_frequency"]
-          id: string
-          is_active: boolean
-          org_id: string
-          title: string
-          updated_at: string
-          version: number
-        }
-        Insert: {
-          created_at?: string
-          description?: string | null
-          frequency?: Database["public"]["Enums"]["audit_frequency"]
-          id?: string
-          is_active?: boolean
-          org_id: string
-          title: string
-          updated_at?: string
-          version?: number
-        }
-        Update: {
-          created_at?: string
-          description?: string | null
-          frequency?: Database["public"]["Enums"]["audit_frequency"]
-          id?: string
-          is_active?: boolean
           org_id?: string
-          title?: string
-          updated_at?: string
-          version?: number
+          reason?: string | null
+          user_id?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "surveys_org_id_fkey"
+            foreignKeyName: "data_access_audit_org_id_fkey"
             columns: ["org_id"]
             isOneToOne: false
             referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "data_access_audit_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
         ]
+      }
+      notifications: {
+        Row: {
+          action_completed_at: string | null
+          action_type: string | null
+          created_at: string
+          id: string
+          is_read: boolean
+          link: string | null
+          message: string
+          read_at: string | null
+          related_id: string | null
+          requires_action: boolean | null
+          title: string
+          type: string
+          user_id: string
+        }
+        Insert: {
+          action_completed_at?: string | null
+          action_type?: string | null
+          created_at?: string
+          id?: string
+          is_read?: boolean
+          link?: string | null
+          message: string
+          read_at?: string | null
+          related_id?: string | null
+          requires_action?: boolean | null
+          title: string
+          type: string
+          user_id: string
+        }
+        Update: {
+          action_completed_at?: string | null
+          action_type?: string | null
+          created_at?: string
+          id?: string
+          is_read?: boolean
+          link?: string | null
+          message?: string
+          read_at?: string | null
+          related_id?: string | null
+          requires_action?: boolean | null
+          title?: string
+          type?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notifications_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      organizations: {
+        Row: {
+          created_at: string
+          gating_policy: string | null
+          id: string
+          name: string
+          time_zone: string
+          updated_at: string
+          week_starts_on: number
+        }
+        Insert: {
+          created_at?: string
+          gating_policy?: string | null
+          id?: string
+          name: string
+          time_zone?: string
+          updated_at?: string
+          week_starts_on?: number
+        }
+        Update: {
+          created_at?: string
+          gating_policy?: string | null
+          id?: string
+          name?: string
+          time_zone?: string
+          updated_at?: string
+          week_starts_on?: number
+        }
+        Relationships: []
       }
       survey_questions: {
         Row: {
@@ -485,6 +644,7 @@ export type Database = {
           required: boolean
           section_id: string
           survey_id: string
+          version: number
           yes_weight: number | null
         }
         Insert: {
@@ -497,6 +657,7 @@ export type Database = {
           required?: boolean
           section_id: string
           survey_id: string
+          version?: number
           yes_weight?: number | null
         }
         Update: {
@@ -509,6 +670,7 @@ export type Database = {
           required?: boolean
           section_id?: string
           survey_id?: string
+          version?: number
           yes_weight?: number | null
         }
         Relationships: [
@@ -535,6 +697,7 @@ export type Database = {
           order_num: number
           survey_id: string
           title: string
+          version: number
         }
         Insert: {
           description?: string | null
@@ -542,6 +705,7 @@ export type Database = {
           order_num?: number
           survey_id: string
           title: string
+          version?: number
         }
         Update: {
           description?: string | null
@@ -549,6 +713,7 @@ export type Database = {
           order_num?: number
           survey_id?: string
           title?: string
+          version?: number
         }
         Relationships: [
           {
@@ -560,44 +725,164 @@ export type Database = {
           },
         ]
       }
+      surveys: {
+        Row: {
+          applicable_branch_ids: string[] | null
+          created_at: string
+          created_by: string | null
+          description: string | null
+          frequency: Database["public"]["Enums"]["audit_frequency"]
+          id: string
+          is_active: boolean
+          org_id: string
+          title: string
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          applicable_branch_ids?: string[] | null
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          frequency?: Database["public"]["Enums"]["audit_frequency"]
+          id?: string
+          is_active?: boolean
+          org_id: string
+          title: string
+          updated_at?: string
+          version?: number
+        }
+        Update: {
+          applicable_branch_ids?: string[] | null
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          frequency?: Database["public"]["Enums"]["audit_frequency"]
+          id?: string
+          is_active?: boolean
+          org_id?: string
+          title?: string
+          updated_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "surveys_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "surveys_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_invitations: {
+        Row: {
+          accepted_at: string | null
+          created_at: string
+          email: string
+          expires_at: string
+          id: string
+          invitation_token: string
+          invited_by: string | null
+          org_id: string
+          role: string
+          updated_at: string
+        }
+        Insert: {
+          accepted_at?: string | null
+          created_at?: string
+          email: string
+          expires_at?: string
+          id?: string
+          invitation_token: string
+          invited_by?: string | null
+          org_id: string
+          role: string
+          updated_at?: string
+        }
+        Update: {
+          accepted_at?: string | null
+          created_at?: string
+          email?: string
+          expires_at?: string
+          id?: string
+          invitation_token?: string
+          invited_by?: string | null
+          org_id?: string
+          role?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_invitations_invited_by_fkey"
+            columns: ["invited_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_invitations_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       users: {
         Row: {
           auth_user_id: string | null
+          avatar_url: string | null
           branch_id: string | null
           created_at: string
           email: string
+          email_verified: boolean
           full_name: string | null
-          avatar_url: string | null
-          signature_url: string | null
           id: string
-          org_id: string
+          is_active: boolean
+          last_seen_at: string | null
+          org_id: string | null
           role: Database["public"]["Enums"]["user_role"]
+          signature_url: string | null
           updated_at: string
         }
         Insert: {
           auth_user_id?: string | null
+          avatar_url?: string | null
           branch_id?: string | null
           created_at?: string
           email: string
+          email_verified?: boolean
           full_name?: string | null
-          avatar_url?: string | null
-          signature_url?: string | null
           id?: string
-          org_id: string
+          is_active?: boolean
+          last_seen_at?: string | null
+          org_id?: string | null
           role: Database["public"]["Enums"]["user_role"]
+          signature_url?: string | null
           updated_at?: string
         }
         Update: {
           auth_user_id?: string | null
+          avatar_url?: string | null
           branch_id?: string | null
           created_at?: string
           email?: string
+          email_verified?: boolean
           full_name?: string | null
-          avatar_url?: string | null
-          signature_url?: string | null
           id?: string
-          org_id?: string
+          is_active?: boolean
+          last_seen_at?: string | null
+          org_id?: string | null
           role?: Database["public"]["Enums"]["user_role"]
+          signature_url?: string | null
           updated_at?: string
         }
         Relationships: [
@@ -736,32 +1021,273 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      _actor_user_id: { Args: never; Returns: string }
+      _user_is_admin_for_org: { Args: { p_org_id: string }; Returns: boolean }
+      _user_org_match: { Args: { p_org_id: string }; Returns: boolean }
+      branch_has_auditor_coverage: {
+        Args: { p_branch_id: string }
+        Returns: boolean
+      }
+      can_manage_auditor_assignment: {
+        Args: { target_user_id: string }
+        Returns: boolean
+      }
       create_audit_with_cycle_guard: {
         Args: {
-          p_org_id: string
-          p_branch_id: string
-          p_survey_id: string
           p_assigned_to: string
-        }
-        Returns: Tables<'audits'>
-      }
-      ensure_current_period_scheduling: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
-      get_org_period_bounds: {
-        Args: {
+          p_branch_id: string
           p_org_id: string
-          p_frequency: Database['public']['Enums']['audit_frequency']
+          p_survey_id: string
         }
         Returns: {
-          start_at: string
+          approval_name: string | null
+          approval_note: string | null
+          approval_signature_type: string | null
+          approval_signature_url: string | null
+          approved_at: string | null
+          approved_by: string | null
+          archived_at: string | null
+          assigned_to: string | null
+          branch_id: string
+          completed_at: string | null
+          completed_by: string | null
+          created_at: string
+          created_by: string | null
+          created_origin: string | null
+          due_at: string
+          id: string
+          is_archived: boolean
+          na_reasons: Json
+          org_id: string
+          override_notes: Json
+          override_scores: Json
+          period_end: string
+          period_start: string
+          rejected_at: string | null
+          rejected_by: string | null
+          rejection_note: string | null
+          responses: Json
+          section_comments: Json
+          started_at: string | null
+          started_by: string | null
+          status: Database["public"]["Enums"]["audit_status"]
+          submitted_at: string | null
+          submitted_by: string | null
+          survey_id: string
+          survey_version: number
+          updated_at: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "audits"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
+      current_app_user_id: { Args: never; Returns: string }
+      current_user_id: { Args: never; Returns: string }
+      current_user_org_id: { Args: never; Returns: string }
+      current_user_role: {
+        Args: never
+        Returns: Database["public"]["Enums"]["user_role"]
+      }
+      ensure_current_period_scheduling: { Args: never; Returns: undefined }
+      fn_branch_covered_after_change: {
+        Args: {
+          p_branch_id: string
+          p_new_branch_ids: string[]
+          p_new_zone_ids: string[]
+          p_user_id: string
+        }
+        Returns: boolean
+      }
+      generate_invitation_token: { Args: never; Returns: string }
+      get_org_config: { Args: { p_org_id: string }; Returns: Json }
+      get_org_period_bounds: {
+        Args: {
+          p_frequency: Database["public"]["Enums"]["audit_frequency"]
+          p_org_id: string
+        }
+        Returns: {
           end_at: string
+          start_at: string
+        }[]
+      }
+      is_admin: { Args: never; Returns: boolean }
+      is_admin_or_super: { Args: never; Returns: boolean }
+      is_current_user_super_admin: { Args: never; Returns: boolean }
+      is_dev_mode: { Args: never; Returns: boolean }
+      is_super_admin: { Args: never; Returns: boolean }
+      log_data_access: {
+        Args: {
+          p_action: string
+          p_export_scope: Json
+          p_org_id: string
+          p_reason: string
+        }
+        Returns: undefined
+      }
+      my_org_id: { Args: never; Returns: string }
+      publish_survey_version: {
+        Args: {
+          p_applicable_branch_ids?: Json
+          p_description?: string
+          p_frequency?: string
+          p_is_active?: boolean
+          p_sections: Json
+          p_survey_id: string
+          p_title?: string
+        }
+        Returns: number
+      }
+      reassign_open_audits_for_branch: {
+        Args: { p_branch_id: string; p_to_user: string }
+        Returns: number
+      }
+      reassign_unstarted_audits_for_branch: {
+        Args: { p_branch_id: string; p_to_user: string }
+        Returns: number
+      }
+      reassign_unstarted_audits_for_branches: {
+        Args: { p_branch_ids: string[]; p_to_user: string }
+        Returns: number
+      }
+      set_audit_approval: {
+        Args: {
+          p_approval_name?: string
+          p_audit_id: string
+          p_note?: string
+          p_signature_type?: string
+          p_signature_url?: string
+          p_status: string
+          p_user_id: string
+        }
+        Returns: {
+          approval_name: string | null
+          approval_note: string | null
+          approval_signature_type: string | null
+          approval_signature_url: string | null
+          approved_at: string | null
+          approved_by: string | null
+          archived_at: string | null
+          assigned_to: string | null
+          branch_id: string
+          completed_at: string | null
+          completed_by: string | null
+          created_at: string
+          created_by: string | null
+          created_origin: string | null
+          due_at: string
+          id: string
+          is_archived: boolean
+          na_reasons: Json
+          org_id: string
+          override_notes: Json
+          override_scores: Json
+          period_end: string
+          period_start: string
+          rejected_at: string | null
+          rejected_by: string | null
+          rejection_note: string | null
+          responses: Json
+          section_comments: Json
+          started_at: string | null
+          started_by: string | null
+          status: Database["public"]["Enums"]["audit_status"]
+          submitted_at: string | null
+          submitted_by: string | null
+          survey_id: string
+          survey_version: number
+          updated_at: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "audits"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
+      set_audit_assigned_to: {
+        Args: { p_audit_id: string; p_to_user: string }
+        Returns: undefined
+      }
+      set_auditor_assignment: {
+        Args: {
+          p_branch_ids: string[]
+          p_user_id: string
+          p_zone_ids: string[]
+        }
+        Returns: undefined
+      }
+      set_org_config: {
+        Args: { p_org_id: string; p_payload: Json; p_reason?: string }
+        Returns: Json
+      }
+      submit_audit: {
+        Args: { p_audit_id: string; p_submitted_by: string }
+        Returns: {
+          approval_name: string | null
+          approval_note: string | null
+          approval_signature_type: string | null
+          approval_signature_url: string | null
+          approved_at: string | null
+          approved_by: string | null
+          archived_at: string | null
+          assigned_to: string | null
+          branch_id: string
+          completed_at: string | null
+          completed_by: string | null
+          created_at: string
+          created_by: string | null
+          created_origin: string | null
+          due_at: string
+          id: string
+          is_archived: boolean
+          na_reasons: Json
+          org_id: string
+          override_notes: Json
+          override_scores: Json
+          period_end: string
+          period_start: string
+          rejected_at: string | null
+          rejected_by: string | null
+          rejection_note: string | null
+          responses: Json
+          section_comments: Json
+          started_at: string | null
+          started_by: string | null
+          status: Database["public"]["Enums"]["audit_status"]
+          submitted_at: string | null
+          submitted_by: string | null
+          survey_id: string
+          survey_version: number
+          updated_at: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "audits"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
+      user_assigned_branch_ids: { Args: never; Returns: string[] }
+      user_managed_branch_ids: { Args: never; Returns: string[] }
+      validate_rls_for_current_user: {
+        Args: never
+        Returns: {
+          check_name: string
+          details: string
+          status: string
         }[]
       }
     }
     Enums: {
-      audit_frequency: "DAILY" | "WEEKLY" | "MONTHLY" | "QUARTERLY" | "UNLIMITED"
+      audit_frequency:
+        | "DAILY"
+        | "WEEKLY"
+        | "MONTHLY"
+        | "QUARTERLY"
+        | "UNLIMITED"
       audit_status:
         | "DRAFT"
         | "IN_PROGRESS"
@@ -769,7 +1295,7 @@ export type Database = {
         | "SUBMITTED"
         | "APPROVED"
         | "REJECTED"
-      user_role: "SUPER_ADMIN" | "ADMIN" | "BRANCH_MANAGER" | "AUDITOR"
+      user_role: "SUPER_ADMIN" | "ADMIN" | "AUDITOR" | "BRANCH_MANAGER"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -906,7 +1432,7 @@ export const Constants = {
         "APPROVED",
         "REJECTED",
       ],
-      user_role: ["SUPER_ADMIN", "ADMIN", "BRANCH_MANAGER", "AUDITOR"],
+      user_role: ["SUPER_ADMIN", "ADMIN", "AUDITOR", "BRANCH_MANAGER"],
     },
   },
 } as const

--- a/supabase/functions/invite-user-resend/index.ts
+++ b/supabase/functions/invite-user-resend/index.ts
@@ -1,8 +1,12 @@
 import { createClient } from 'jsr:@supabase/supabase-js@2'
-import { Resend } from 'npm:resend@2.0.0'
-import { corsHeaders } from '../_shared/cors.ts'
 
-const resend = new Resend(Deno.env.get('RESEND_API_KEY'))
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+// Max resend attempts per org per hour
+const RESEND_RATE_LIMIT = 20
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
@@ -13,9 +17,9 @@ Deno.serve(async (req) => {
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL') ?? '',
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+      { auth: { autoRefreshToken: false, persistSession: false } }
     )
 
-    // Verify authentication
     const authHeader = req.headers.get('Authorization')
     if (!authHeader) throw new Error('Missing authorization header')
 
@@ -23,112 +27,103 @@ Deno.serve(async (req) => {
     const { data: { user }, error: userError } = await supabase.auth.getUser(token)
     if (userError || !user) throw new Error('Unauthorized')
 
-    // Check admin role
-    const { data: userData } = await supabase
+    const { data: callerData } = await supabase
       .from('users')
-      .select('role')
-      .eq('id', user.id)
+      .select('role, org_id')
+      .or(`id.eq.${user.id},auth_user_id.eq.${user.id}`)
       .single()
 
-    if (!userData || !['ADMIN', 'SUPER_ADMIN'].includes(userData.role)) {
-      throw new Error('Only admins can invite users')
+    if (!callerData || !['ADMIN', 'SUPER_ADMIN'].includes(callerData.role)) {
+      throw new Error('Only admins can resend invitations')
     }
 
-    const { email, name, role, orgId } = await req.json()
+    const { userId } = await req.json()
+    if (!userId) throw new Error('Missing required field: userId')
 
-    // Generate magic link via Supabase
-    const { data: magicLinkData, error: linkError } = await supabase.auth.admin.generateLink({
-      type: 'magiclink',
-      email,
+    // Look up target user
+    const { data: targetUser, error: lookupError } = await supabase
+      .from('users')
+      .select('email, full_name, role, org_id')
+      .eq('id', userId)
+      .single()
+
+    if (lookupError || !targetUser) throw new Error('User not found')
+
+    // Admins can only resend within their own org
+    if (callerData.role === 'ADMIN' && callerData.org_id !== targetUser.org_id) {
+      throw new Error('Admins can only resend invitations within their own organization')
+    }
+
+    // Rate limit: max RESEND_RATE_LIMIT resends per org per hour
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    const { count: recentCount } = await supabase
+      .from('users')
+      .select('*', { count: 'exact', head: true })
+      .eq('org_id', targetUser.org_id)
+      .gte('updated_at', oneHourAgo)
+
+    if ((recentCount ?? 0) >= RESEND_RATE_LIMIT) {
+      return new Response(
+        JSON.stringify({ error: `Rate limit exceeded: max ${RESEND_RATE_LIMIT} resends per hour per organization`, success: false }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 429 }
+      )
+    }
+
+    // Generate a new invite link
+    const { data: linkData, error: linkError } = await supabase.auth.admin.generateLink({
+      type: 'invite',
+      email: targetUser.email,
       options: {
-        data: { name, role, org_id: orgId },
-        redirectTo: `${req.headers.get('origin')}/login`
-      }
+        data: {
+          name: targetUser.full_name,
+          role: targetUser.role,
+          org_id: targetUser.org_id,
+        },
+        redirectTo: `${req.headers.get('origin')}/login`,
+      },
     })
 
-    if (linkError) throw new Error(`Failed to generate magic link: ${linkError.message}`)
+    if (linkError) throw new Error(`Failed to generate invite link: ${linkError.message}`)
 
-    // Send email via Resend with YOUR branding
-    const { data: emailData, error: emailError } = await resend.emails.send({
-      from: 'Trakr <noreply@yourdomain.com>', // ✅ YOUR EMAIL
-      to: email,
-      subject: `You're invited to join Trakr`,
-      html: `
-        <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-          <div style="text-align: center; margin-bottom: 30px;">
-            <h1 style="color: #4F46E5; margin: 0;">Trakr</h1>
-          </div>
-          
-          <div style="background: #f9fafb; border-radius: 8px; padding: 30px; margin-bottom: 20px;">
-            <h2 style="margin-top: 0; color: #111827;">Welcome to Trakr!</h2>
-            <p style="color: #374151; line-height: 1.6;">Hi ${name},</p>
-            <p style="color: #374151; line-height: 1.6;">
-              You've been invited to join Trakr as a <strong>${role}</strong>. 
-              Click the button below to set up your account and get started.
-            </p>
-            
-            <div style="text-align: center; margin: 30px 0;">
-              <a href="${magicLinkData.properties.action_link}" 
+    // If Resend is configured, send branded email; otherwise rely on Supabase default
+    const resendKey = Deno.env.get('RESEND_API_KEY')
+    if (resendKey) {
+      const { Resend } = await import('npm:resend@2.0.0')
+      const resend = new Resend(resendKey)
+      const fromEmail = Deno.env.get('SMTP_SENDER_EMAIL') || 'noreply@yourdomain.com'
+
+      const { error: emailError } = await resend.emails.send({
+        from: `Trakr <${fromEmail}>`,
+        to: targetUser.email,
+        subject: `Your Trakr invitation`,
+        html: `
+          <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <h1 style="color: #4F46E5;">Trakr</h1>
+            <p>Hi ${targetUser.full_name || targetUser.email},</p>
+            <p>Your invitation to join Trakr as <strong>${targetUser.role}</strong> has been resent.</p>
+            <div style="margin: 30px 0;">
+              <a href="${linkData.properties.action_link}"
                  style="display: inline-block; padding: 14px 28px; background: #4F46E5; color: white; text-decoration: none; border-radius: 6px; font-weight: 500;">
                 Accept Invitation
               </a>
             </div>
-            
-            <p style="color: #6b7280; font-size: 14px; margin-bottom: 0;">
-              Or copy and paste this link into your browser:
-            </p>
-            <p style="color: #4F46E5; font-size: 12px; word-break: break-all; background: white; padding: 10px; border-radius: 4px; margin-top: 10px;">
-              ${magicLinkData.properties.action_link}
-            </p>
+            <p style="color: #6b7280; font-size: 13px;">This link expires in 24 hours.</p>
           </div>
-          
-          <div style="text-align: center; color: #9ca3af; font-size: 12px;">
-            <p>This invitation will expire in 24 hours.</p>
-            <p>If you didn't expect this invitation, you can safely ignore this email.</p>
-          </div>
-        </div>
-      `
-    })
-
-    if (emailError) throw new Error(`Failed to send email: ${emailError.message}`)
-
-    // Create user in database
-    const { data: newUser, error: dbError } = await supabase
-      .from('users')
-      .insert({
-        email,
-        full_name: name,
-        role: role.toUpperCase(),
-        org_id: orgId,
-        email_verified: false,
-        is_active: true,
+        `,
       })
-      .select()
-      .single()
 
-    if (dbError) throw new Error(`Failed to create user: ${dbError.message}`)
+      if (emailError) throw new Error(`Failed to send email: ${emailError.message}`)
+    }
 
     return new Response(
-      JSON.stringify({ 
-        success: true,
-        user: newUser,
-        emailId: emailData?.id
-      }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 200
-      }
+      JSON.stringify({ success: true, message: `Invitation resent to ${targetUser.email}` }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
     )
 
   } catch (error) {
     return new Response(
-      JSON.stringify({ 
-        error: error instanceof Error ? error.message : 'An error occurred'
-      }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 400
-      }
+      JSON.stringify({ error: error instanceof Error ? error.message : 'An error occurred', success: false }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
     )
   }
 })

--- a/supabase/functions/invite-user/index.ts
+++ b/supabase/functions/invite-user/index.ts
@@ -1,146 +1,111 @@
 // Invite User Edge Function
 // Sends invitation emails using Supabase Auth's built-in email system
-// Email will come from: noreply@mail.supabase.io (default)
-// 
-// To use YOUR email domain:
-// 1. Go to Supabase Dashboard → Settings → Authentication → SMTP Settings
-// 2. Configure your email provider (Gmail, SendGrid, etc.)
-// 3. See EMAIL_SENDER_OPTIONS.md for detailed setup
 
 import { createClient } from 'jsr:@supabase/supabase-js@2'
-import { corsHeaders } from '../_shared/cors.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+// Max invites per org per hour to prevent abuse
+const INVITE_RATE_LIMIT = 20
 
 Deno.serve(async (req) => {
-  // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
   }
 
   try {
-    // Create Supabase client with service role key
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL') ?? '',
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-      {
-        auth: {
-          autoRefreshToken: false,
-          persistSession: false
-        }
-      }
+      { auth: { autoRefreshToken: false, persistSession: false } }
     )
 
-    // Verify the request is authenticated
+    // Verify caller is authenticated
     const authHeader = req.headers.get('Authorization')
-    if (!authHeader) {
-      throw new Error('Missing authorization header')
-    }
+    if (!authHeader) throw new Error('Missing authorization header')
 
-    // Verify the calling user is an admin
     const token = authHeader.replace('Bearer ', '')
     const { data: { user }, error: userError } = await supabase.auth.getUser(token)
-    
-    if (userError || !user) {
-      throw new Error('Unauthorized')
-    }
+    if (userError || !user) throw new Error('Unauthorized')
 
-    // Check if user is admin
-    const { data: userData } = await supabase
+    // Check caller is admin or super admin
+    const { data: callerData } = await supabase
       .from('users')
-      .select('role')
-      .eq('id', user.id)
+      .select('role, org_id')
+      .or(`id.eq.${user.id},auth_user_id.eq.${user.id}`)
       .single()
 
-    if (!userData || !['ADMIN', 'SUPER_ADMIN'].includes(userData.role)) {
+    if (!callerData || !['ADMIN', 'SUPER_ADMIN'].includes(callerData.role)) {
       throw new Error('Only admins can invite users')
     }
 
-    // Parse request body
     const { email, name, role, orgId } = await req.json()
 
-    // Validate inputs
     if (!email || !name || !role || !orgId) {
       throw new Error('Missing required fields: email, name, role, orgId')
     }
 
-    // Check if user already exists in auth.users
-    const { data: existingAuthUsers } = await supabase.auth.admin.listUsers()
-    const userExists = existingAuthUsers?.users.some(u => u.email === email)
-    
-    if (userExists) {
-      throw new Error('User with this email already exists')
+    // Admins can only invite into their own org; super admins can invite into any
+    if (callerData.role === 'ADMIN' && callerData.org_id !== orgId) {
+      throw new Error('Admins can only invite users into their own organization')
     }
 
-    // Invite user via Supabase Auth
-    // This automatically sends an invitation email
-    // Default: from noreply@mail.supabase.io
-    // To customize: Configure SMTP in Supabase Dashboard
+    // Rate limit: max INVITE_RATE_LIMIT invites per org per hour
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    const { count: recentInviteCount } = await supabase
+      .from('users')
+      .select('*', { count: 'exact', head: true })
+      .eq('org_id', orgId)
+      .gte('created_at', oneHourAgo)
+
+    if ((recentInviteCount ?? 0) >= INVITE_RATE_LIMIT) {
+      return new Response(
+        JSON.stringify({ error: `Rate limit exceeded: max ${INVITE_RATE_LIMIT} invites per hour per organization`, success: false }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 429 }
+      )
+    }
+
+    // Check if user already exists
+    const { data: existingUser } = await supabase
+      .from('users')
+      .select('id')
+      .eq('email', email)
+      .maybeSingle()
+
+    if (existingUser) throw new Error('User with this email already exists')
+
+    // Send invite via Supabase Auth
     const { data: authUser, error: authError } = await supabase.auth.admin.inviteUserByEmail(email, {
-      data: {
-        name,
-        role,
-        org_id: orgId
-      },
+      data: { name, role, org_id: orgId },
       redirectTo: `${req.headers.get('origin')}/login`
     })
 
-    if (authError) {
-      throw new Error(`Failed to send invitation: ${authError.message}`)
-    }
+    if (authError) throw new Error(`Failed to send invitation: ${authError.message}`)
 
-    // Create user record in our users table
-    const { data: newUser, error: dbError } = await supabase
+    // Fetch the trigger-created user row
+    const { data: newUser, error: fetchError } = await supabase
       .from('users')
-      .insert({
-        id: authUser.user?.id,
-        email,
-        full_name: name,
-        role: role.toUpperCase(),
-        org_id: orgId,
-        email_verified: false,
-        is_active: true,
-      })
       .select()
+      .eq('id', authUser.user!.id)
       .single()
 
-    if (dbError) {
-      // Rollback: Delete from auth if DB insert fails
+    if (fetchError || !newUser) {
       await supabase.auth.admin.deleteUser(authUser.user!.id)
-      throw new Error(`Failed to create user record: ${dbError.message}`)
+      throw new Error('User record not found after invite — trigger may have failed')
     }
 
-    console.log(`✅ User invited successfully: ${email} as ${role}`)
-    console.log(`📧 Email sent from: ${Deno.env.get('SMTP_SENDER_EMAIL') || 'noreply@mail.supabase.io'}`)
-
     return new Response(
-      JSON.stringify({ 
-        success: true,
-        user: newUser,
-        message: `Invitation sent to ${email}`
-      }),
-      {
-        headers: { 
-          ...corsHeaders,
-          'Content-Type': 'application/json' 
-        },
-        status: 200
-      }
+      JSON.stringify({ success: true, user: newUser, message: `Invitation sent to ${email}` }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
     )
 
   } catch (error) {
-    console.error('❌ Error inviting user:', error)
-    
     return new Response(
-      JSON.stringify({ 
-        error: error instanceof Error ? error.message : 'An error occurred',
-        success: false
-      }),
-      {
-        headers: { 
-          ...corsHeaders,
-          'Content-Type': 'application/json' 
-        },
-        status: 400
-      }
+      JSON.stringify({ error: error instanceof Error ? error.message : 'An error occurred', success: false }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
     )
   }
 })

--- a/supabase/migrations/20260405114121_fix_handle_new_user_trigger.sql
+++ b/supabase/migrations/20260405114121_fix_handle_new_user_trigger.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- Fix handle_new_user trigger
+-- 1. Set auth_user_id = NEW.id so the auth ↔ public.users link is explicit
+-- 2. Accept both 'name' and 'full_name' from raw_user_meta_data (Edge Function
+--    sends 'name'; direct sign-up flows may send 'full_name')
+-- 3. Default role to AUDITOR instead of ADMIN (least-privilege default)
+-- 4. Add ON CONFLICT (id) DO NOTHING to prevent duplicate-key errors if any
+--    caller also inserts directly (defence in depth)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.users (
+    id,
+    auth_user_id,
+    email,
+    full_name,
+    role,
+    org_id,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    NEW.id,
+    NEW.id,
+    NEW.email,
+    COALESCE(
+      NEW.raw_user_meta_data->>'full_name',
+      NEW.raw_user_meta_data->>'name',
+      split_part(NEW.email, '@', 1)
+    ),
+    COALESCE(NEW.raw_user_meta_data->>'role', 'AUDITOR'),
+    (NEW.raw_user_meta_data->>'org_id')::UUID,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Ensure the trigger is attached (idempotent)
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_new_user();


### PR DESCRIPTION
## Summary
Backend/auth slice of the in-flight work, split out for reviewability:

- **invite-user** edge function: server-side admin check (`id`/`auth_user_id` tolerant), org scoping, rate limiting, relies on the `handle_new_user` trigger (no more double-insert)
- **invite-user-resend**: real implementation (`generateLink` + Resend email) replacing the old no-op stub
- **supabaseApi**: removed auth-less `createUser()` (users could never log in), `resendInvitation()` now invokes the edge function, photo upload failures throw instead of silently saving blob URLs, nullable `org_id` bridged
- **auth store**: removed dead `mockUsers` block
- **Sentry**: `sendDefaultPii: false`
- **shared types**: regenerated `Database` types from the live schema
- **migration**: committed `20260405114121_fix_handle_new_user_trigger.sql` matching the already-applied live version (verified byte-identical via `pg_get_functiondef`)
- **tsconfig**: dropped the broken `tsconfig.test.json` project reference (root cause of the TS6305 `setupTests.d.ts` error that CI worked around with `grep -v setupTests`)
- removed dead `useAuditAutoSave` hook (never wired; AuditWizard has its own `saveProgress` mutation)

## Testing
- `tsc --noEmit`: zero errors in all touched files (42 pre-existing errors in untouched files remain; fixed in the upcoming CI-gate PR)
- `vitest run`: 18 passed / 0 failed (integration suites hit a pre-existing local Node 24 + jsdom AbortSignal issue, unrelated)
- `vite build`: green
- Live function definition compared against migration content before renaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)