### PR TITLE
fix: database hardening — RLS cleanup, storage policies, RPC grants, honest rate limits

### DIFF
--- a/apps/web/src/utils/supabaseApi.ts
+++ b/apps/web/src/utils/supabaseApi.ts
@@ -64,7 +64,7 @@ const mapBranch = (row: Tables<'branches'>): Branch => ({
   address: row.address || undefined,
   orgId: row.org_id,
   managerId: row.manager_id || undefined,
-  isActive: (row as any).is_active ?? false,
+  isActive: (row as any).is_active !== false, // DB default is true; align with mapUser
   createdAt: new Date(row.created_at),
   updatedAt: new Date(row.updated_at),
 })

--- a/scripts/seed-with-credentials.js
+++ b/scripts/seed-with-credentials.js
@@ -282,6 +282,25 @@ async function seedDatabase() {
     console.log('  • 8 Branches (Manhattan, Brooklyn, Miami, Atlanta, LA, SF, Dallas, Houston)')
     console.log('  • 7 Users (1 admin, 3 branch managers, 3 auditors)')
     
+    // Link freshly seeded public.users rows to their auth accounts. The seed
+    // recreates rows with new ids; without auth_user_id the org-scoped RLS
+    // policies hide every row from the logged-in user and login fails.
+    console.log('\n🔗 Linking users to auth accounts...')
+    const { data: authList, error: authListError } = await supabase.auth.admin.listUsers({ perPage: 1000 })
+    if (authListError) throw authListError
+    let linked = 0
+    for (const authUser of authList.users) {
+      if (!authUser.email) continue
+      const { data: updated, error: linkError } = await supabase
+        .from('users')
+        .update({ auth_user_id: authUser.id })
+        .ilike('email', authUser.email)
+        .select('id')
+      if (linkError) throw linkError
+      linked += (updated || []).length
+    }
+    console.log(`✅ Linked ${linked} user rows to auth accounts`)
+
     console.log('\n🔐 Test User Accounts:')
     console.log('  Super Admin: admin@trakr.com')
     console.log('  Admin: admin@retailchain.com')

--- a/supabase/functions/invite-user-resend/index.ts
+++ b/supabase/functions/invite-user-resend/index.ts
@@ -29,7 +29,7 @@ Deno.serve(async (req) => {
 
     const { data: callerData } = await supabase
       .from('users')
-      .select('role, org_id')
+      .select('id, role, org_id')
       .or(`id.eq.${user.id},auth_user_id.eq.${user.id}`)
       .single()
 
@@ -54,13 +54,15 @@ Deno.serve(async (req) => {
       throw new Error('Admins can only resend invitations within their own organization')
     }
 
-    // Rate limit: max RESEND_RATE_LIMIT resends per org per hour
+    // Rate limit: max RESEND_RATE_LIMIT resends per org per hour, counted from
+    // logged resend events (user-row updated_at matched any profile edit)
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
     const { count: recentCount } = await supabase
-      .from('users')
+      .from('activity_logs')
       .select('*', { count: 'exact', head: true })
       .eq('org_id', targetUser.org_id)
-      .gte('updated_at', oneHourAgo)
+      .eq('action', 'invite_resent')
+      .gte('created_at', oneHourAgo)
 
     if ((recentCount ?? 0) >= RESEND_RATE_LIMIT) {
       return new Response(
@@ -85,9 +87,16 @@ Deno.serve(async (req) => {
 
     if (linkError) throw new Error(`Failed to generate invite link: ${linkError.message}`)
 
-    // If Resend is configured, send branded email; otherwise rely on Supabase default
+    // generateLink does NOT send email — without a configured sender the resend
+    // would silently deliver nothing, so fail loudly instead
     const resendKey = Deno.env.get('RESEND_API_KEY')
-    if (resendKey) {
+    if (!resendKey) {
+      return new Response(
+        JSON.stringify({ error: 'Email delivery is not configured (RESEND_API_KEY missing) — invitation was not sent', success: false }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 503 }
+      )
+    }
+    {
       const { Resend } = await import('npm:resend@2.0.0')
       const resend = new Resend(resendKey)
       const fromEmail = Deno.env.get('SMTP_SENDER_EMAIL') || 'noreply@yourdomain.com'
@@ -114,6 +123,15 @@ Deno.serve(async (req) => {
 
       if (emailError) throw new Error(`Failed to send email: ${emailError.message}`)
     }
+
+    await supabase.from('activity_logs').insert({
+      org_id: targetUser.org_id,
+      user_id: callerData.id,
+      action: 'invite_resent',
+      entity_type: 'user',
+      entity_id: userId,
+      details: `Resent invitation to ${targetUser.email}`,
+    })
 
     return new Response(
       JSON.stringify({ success: true, message: `Invitation resent to ${targetUser.email}` }),

--- a/supabase/functions/invite-user/index.ts
+++ b/supabase/functions/invite-user/index.ts
@@ -34,7 +34,7 @@ Deno.serve(async (req) => {
     // Check caller is admin or super admin
     const { data: callerData } = await supabase
       .from('users')
-      .select('role, org_id')
+      .select('id, role, org_id')
       .or(`id.eq.${user.id},auth_user_id.eq.${user.id}`)
       .single()
 
@@ -53,12 +53,14 @@ Deno.serve(async (req) => {
       throw new Error('Admins can only invite users into their own organization')
     }
 
-    // Rate limit: max INVITE_RATE_LIMIT invites per org per hour
+    // Rate limit: max INVITE_RATE_LIMIT invites per org per hour, counted from
+    // logged invite events (user-row counts also matched signups/edits)
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
     const { count: recentInviteCount } = await supabase
-      .from('users')
+      .from('activity_logs')
       .select('*', { count: 'exact', head: true })
       .eq('org_id', orgId)
+      .eq('action', 'user_invited')
       .gte('created_at', oneHourAgo)
 
     if ((recentInviteCount ?? 0) >= INVITE_RATE_LIMIT) {
@@ -96,6 +98,15 @@ Deno.serve(async (req) => {
       await supabase.auth.admin.deleteUser(authUser.user!.id)
       throw new Error('User record not found after invite — trigger may have failed')
     }
+
+    await supabase.from('activity_logs').insert({
+      org_id: orgId,
+      user_id: callerData.id,
+      action: 'user_invited',
+      entity_type: 'user',
+      entity_id: newUser.id,
+      details: `Invited ${email} as ${role}`,
+    })
 
     return new Response(
       JSON.stringify({ success: true, user: newUser, message: `Invitation sent to ${email}` }),

--- a/supabase/migrations/20260405114609_storage_bucket_security.sql
+++ b/supabase/migrations/20260405114609_storage_bucket_security.sql
@@ -1,0 +1,7 @@
+-- Restrict file uploads: 10 MB max, images only
+-- (Recovered from live supabase_migrations.schema_migrations — applied 2026-04-05.)
+UPDATE storage.buckets
+SET
+  file_size_limit = 10485760,
+  allowed_mime_types = ARRAY['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif']
+WHERE id IN ('audit-photos', 'profile-media');

--- a/supabase/migrations/20260405114711_add_missing_user_branch_columns.sql
+++ b/supabase/migrations/20260405114711_add_missing_user_branch_columns.sql
@@ -1,0 +1,10 @@
+-- Add missing columns to public.users
+-- (Recovered from live supabase_migrations.schema_migrations — applied 2026-04-05.)
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS email_verified boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS last_seen_at timestamptz;
+
+-- Add missing is_active column to branches
+ALTER TABLE public.branches
+  ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true;

--- a/supabase/migrations/20260703150413_rls_cleanup_legacy_policies.sql
+++ b/supabase/migrations/20260703150413_rls_cleanup_legacy_policies.sql
@@ -1,0 +1,72 @@
+-- ============================================================================
+-- Production RLS cleanup
+-- 1. branch_manager_assignments: two legacy always-true policies coexist with
+--    the org-scoped *_policy generation; permissive policies OR together, so
+--    the legacy ones bypass RLS entirely for any authenticated user.
+-- 2. notifications: legacy INSERT was WITH CHECK (true) (cross-org spam);
+--    the *_policy INSERT was super-admin-only (breaks app notifications).
+--    Replace with same-org sender→recipient. Also drop the auth.uid()=user_id
+--    generation (user_id is public.users.id, not the auth uid) and the
+--    duplicate owner_only update policy.
+-- 3. handle_new_user: pin search_path (advisor 0011_function_search_path_mutable).
+-- 4. Revoke anon EXECUTE on RPCs. Predicate helpers (is_*, current_*, ...)
+--    stay anon-executable: policies on tables with public read paths
+--    (e.g. app_config) evaluate them in anon contexts.
+-- 5. Backfill users.auth_user_id where an auth user with the same email
+--    exists (3 rows: legacy seeded users predating the linkage column).
+-- ============================================================================
+
+-- 1. branch_manager_assignments
+DROP POLICY IF EXISTS "Anyone authenticated can manage branch manager assignments" ON public.branch_manager_assignments;
+DROP POLICY IF EXISTS "Anyone authenticated can view branch manager assignments" ON public.branch_manager_assignments;
+
+-- 2. notifications
+DROP POLICY IF EXISTS "Authenticated users can create notifications" ON public.notifications;
+DROP POLICY IF EXISTS "Users can view own notifications" ON public.notifications;
+DROP POLICY IF EXISTS "Users can update own notifications" ON public.notifications;
+DROP POLICY IF EXISTS "Users can delete own notifications" ON public.notifications;
+DROP POLICY IF EXISTS notifications_update_owner_only ON public.notifications;
+DROP POLICY IF EXISTS notifications_insert_policy ON public.notifications;
+
+CREATE POLICY notifications_insert_policy ON public.notifications
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    is_super_admin()
+    OR EXISTS (
+      SELECT 1
+      FROM public.users sender
+      JOIN public.users recipient ON recipient.org_id = sender.org_id
+      WHERE (sender.auth_user_id = auth.uid() OR sender.id = auth.uid())
+        AND recipient.id = notifications.user_id
+    )
+  );
+
+-- 3. search_path
+ALTER FUNCTION public.handle_new_user() SET search_path = public, pg_temp;
+
+-- 4. anon RPC revokes
+DO $$
+DECLARE fn regprocedure;
+BEGIN
+  FOR fn IN
+    SELECT p.oid::regprocedure
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname IN (
+        'create_audit_with_cycle_guard','ensure_current_period_scheduling',
+        'reassign_open_audits_for_branch','reassign_unstarted_audits_for_branches',
+        'set_audit_approval','set_audit_assigned_to','set_auditor_assignment',
+        'set_org_config','submit_audit','log_data_access',
+        'validate_rls_for_current_user','handle_new_user'
+      )
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM anon', fn);
+  END LOOP;
+END $$;
+
+-- 5. auth linkage backfill
+UPDATE public.users pu
+SET auth_user_id = au.id, updated_at = now()
+FROM auth.users au
+WHERE lower(au.email) = lower(pu.email)
+  AND pu.auth_user_id IS NULL;

--- a/supabase/migrations/20260703150433_storage_prod_policies.sql
+++ b/supabase/migrations/20260703150433_storage_prod_policies.sql
@@ -1,0 +1,36 @@
+-- ============================================================================
+-- Production storage policies
+-- The dev_* generation granted anon INSERT/UPDATE/DELETE on both buckets —
+-- anyone holding the public anon key could upload, overwrite, or delete
+-- photos. No non-dev policies existed, so scoped replacements are created
+-- here (dropping without replacing would break uploads).
+--
+-- App usage (supabaseApi.ts): upload with upsert:true (INSERT + UPDATE),
+-- reads via public bucket URLs (no SELECT policy needed — omitting it also
+-- closes the listing/enumeration advisor warning), no deletes.
+-- ============================================================================
+
+DROP POLICY IF EXISTS dev_audit_photos_select ON storage.objects;
+DROP POLICY IF EXISTS dev_audit_photos_insert ON storage.objects;
+DROP POLICY IF EXISTS dev_audit_photos_update ON storage.objects;
+DROP POLICY IF EXISTS dev_audit_photos_delete ON storage.objects;
+DROP POLICY IF EXISTS dev_select_audit_photos ON storage.objects;
+DROP POLICY IF EXISTS dev_insert_audit_photos ON storage.objects;
+DROP POLICY IF EXISTS dev_delete_audit_photos ON storage.objects;
+DROP POLICY IF EXISTS dev_select_profile_media ON storage.objects;
+DROP POLICY IF EXISTS dev_insert_profile_media ON storage.objects;
+DROP POLICY IF EXISTS dev_delete_profile_media ON storage.objects;
+DROP POLICY IF EXISTS dev_profile_media_select ON storage.objects;
+DROP POLICY IF EXISTS dev_profile_media_insert ON storage.objects;
+DROP POLICY IF EXISTS dev_profile_media_read ON storage.objects;
+DROP POLICY IF EXISTS dev_profile_media_update ON storage.objects;
+DROP POLICY IF EXISTS dev_profile_media_delete ON storage.objects;
+
+CREATE POLICY app_media_insert ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id IN ('audit-photos', 'profile-media'));
+
+CREATE POLICY app_media_update ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (bucket_id IN ('audit-photos', 'profile-media'))
+  WITH CHECK (bucket_id IN ('audit-photos', 'profile-media'));

--- a/supabase/migrations/20260703150544_rpc_grants_authenticated_only.sql
+++ b/supabase/migrations/20260703150544_rpc_grants_authenticated_only.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- RPC EXECUTE grants: authenticated + service_role only.
+-- The prior revoke targeted only `anon`, but these functions carry the
+-- default PUBLIC grant, which anon inherits. Revoke from PUBLIC and grant
+-- back explicitly. Predicate helpers keep PUBLIC EXECUTE deliberately:
+-- they are evaluated inside RLS policies on tables with public read paths
+-- (e.g. app_config pre-login dev_mode check).
+-- ============================================================================
+DO $$
+DECLARE fn regprocedure;
+BEGIN
+  FOR fn IN
+    SELECT p.oid::regprocedure
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname IN (
+        'create_audit_with_cycle_guard','ensure_current_period_scheduling',
+        'reassign_open_audits_for_branch','reassign_unstarted_audits_for_branches',
+        'set_audit_approval','set_audit_assigned_to','set_auditor_assignment',
+        'set_org_config','submit_audit','log_data_access',
+        'validate_rls_for_current_user','handle_new_user'
+      )
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon', fn);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', fn);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
Closes the multi-tenant security gaps found by the Supabase advisors, and makes the repo's migration history match the live database exactly.

**Migrations** (already applied live; files carry the `schema_migrations` version stamps):
- `rls_cleanup_legacy_policies` — drops the always-true policies on `branch_manager_assignments` (any authenticated user could manage assignments **across orgs**) and `notifications`; adds a same-org sender→recipient INSERT policy (the surviving `*_policy` INSERT was super-admin-only and would have broken app notifications); pins `handle_new_user` search_path; backfills `users.auth_user_id` by email (3 legacy rows)
- `storage_prod_policies` — removes `dev_*` policies that granted **anon** INSERT/UPDATE/DELETE on both buckets; replaces with authenticated INSERT/UPDATE (uploads use `upsert:true`); omitting SELECT closes the listing/enumeration warning while public-URL reads continue
- `rpc_grants_authenticated_only` — strips PUBLIC/anon EXECUTE from 12 RPCs (first pass only revoked `anon`, but the PUBLIC grant let anon inherit)
- Recovers `storage_bucket_security` + `add_missing_user_branch_columns` files from live history — **repo migrations now == applied history**

**Edge functions:**
- Rate limits count real logged events in `activity_logs` (old proxies counted *any* user row created/updated in the hour)
- `invite-user-resend` returns 503 when `RESEND_API_KEY` is missing — `generateLink` sends no email, so the old "success" was a silent no-op
- Both functions log invite/resend events (rate-limit source + audit trail)

**Web:** `mapBranch.isActive` defaults `true` (DB default; aligns with `mapUser`)

## Verification
- Advisors re-run: always-true RLS, mutable search_path, bucket-listing warnings **cleared**; anon-executable SECURITY DEFINER 27→15 (all remaining are predicate helpers evaluated by public-read policies — documented in the migration)
- Post-hardening e2e locally: auth, RLS access-control, users/branches CRUD all green against the live DB
- Functions redeploy follows merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)