### PR TITLE
fix(tsconfig): drop deprecated baseUrl, paths already config-relative

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,7 +22,6 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Path mapping */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@trakr/shared": ["../../packages/shared/src"]


### PR DESCRIPTION
## Summary
`apps/web/tsconfig.json` used `baseUrl: "."` for its `paths` mapping — TS 5.9 flags this as deprecated (removed in TS 7.0). Since TS 4.1+, `paths` resolve relative to the tsconfig's own directory when `baseUrl` is absent, which is identical to the current `baseUrl: "."`. One-line removal, behavior-neutral.

Vite's `resolve.alias` in `vite.config.ts` is a separate, independent config (confirmed by inspection) — unaffected by this change; it already mirrors the same `@/*` and `@trakr/shared` aliases.

## Testing
- `tsc --noEmit`: 0 errors, deprecation warning gone
- No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)