### PR TITLE
fix(observability): wire real errors into Sentry

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -8,7 +8,7 @@ import { ThemeProvider } from './contexts/ThemeContext'
 import './index.css'
 import { emitToast } from './utils/toastBus'
 import { apiErrorMessage } from './utils/apiError'
-import { initSentry, captureMessage } from './utils/sentry'
+import { initSentry, captureMessage, captureException } from './utils/sentry'
 import { ensureClientEnv, formatMissingHtml } from '@trakr/shared'
 import { useApiHealthStore, monitoredQueryLabel } from './stores/apiHealth'
 
@@ -62,6 +62,7 @@ const queryClient = new QueryClient({
       if (label) {
         useApiHealthStore.getState().setIssue(label, apiErrorMessage(error, `${label} failed`))
       }
+      captureException(error, { queryKey: query.queryKey, label })
     },
     onSuccess: (_data, query) => {
       const label = monitoredQueryLabel(query.queryKey)
@@ -71,8 +72,9 @@ const queryClient = new QueryClient({
     },
   }),
   mutationCache: new MutationCache({
-    onError: (error) => {
+    onError: (error, _variables, _context, mutation) => {
       emitToast({ message: apiErrorMessage(error, 'Action failed'), variant: 'error' })
+      captureException(error, { mutationKey: mutation.options.mutationKey })
     },
   }),
   defaultOptions: {

--- a/apps/web/src/utils/errorHandler.ts
+++ b/apps/web/src/utils/errorHandler.ts
@@ -239,31 +239,36 @@ export class ErrorHandler {
   }
 
   static logError(error: AppError): void {
+    // AppError only stores the flattened message/stack (see createError), not the
+    // original Error instance — reconstruct one so exactly one of the log lines
+    // below can reach Sentry via logger.error's error-arg gate (logger.ts:64).
+    const reconstructed = new Error(error.message)
+    if (typeof error.context?.originalStack === 'string') {
+      reconstructed.stack = error.context.originalStack
+    }
+
     // Log using structured logger
     logger.group(`${error.severity.toUpperCase()} Error: ${error.code}`, () => {
-      logger.error('User Message', undefined, { 
+      logger.error('User Message', undefined, {
         context: 'ErrorHandler',
         data: { userMessage: error.userMessage }
       })
-      logger.error('Technical Message', undefined, { 
+      logger.error('Technical Message', reconstructed, {
         context: 'ErrorHandler',
-        data: { message: error.message }
+        data: { code: error.code, severity: error.severity }
       })
       if (error.context) {
-        logger.error('Error Context', undefined, { 
+        logger.error('Error Context', undefined, {
           context: 'ErrorHandler',
           data: error.context
         })
       }
-      logger.error('Timestamp', undefined, { 
+      logger.error('Timestamp', undefined, {
         context: 'ErrorHandler',
         data: { timestamp: error.timestamp }
       })
     })
-    
-    // In production, you could send to error tracking service
-    // Example: Sentry.captureException(error)
-    
+
     // Store in local storage for debugging (limit to last 50 errors)
     try {
       const stored = safeLocalStorage.getObject<AppError[]>('trakr_errors', []) || []

--- a/apps/web/src/utils/logger.ts
+++ b/apps/web/src/utils/logger.ts
@@ -8,6 +8,8 @@
  * - Prevents sensitive data leakage in production
  */
 
+import { captureException, setContext } from './sentry';
+
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 interface LogOptions {
@@ -71,23 +73,21 @@ class Logger {
    */
   private sendToSentry(error: Error | unknown, message: string, options?: LogOptions): void {
     try {
-      // Dynamic import to avoid bundling Sentry in development
-      import('./sentry').then(({ captureException, setContext }) => {
-        // Add context if provided
-        if (options?.context || options?.data) {
-          setContext('logger', {
-            context: options?.context,
-            data: options?.data,
-          });
-        }
+      // sentry.ts is already statically imported (and thus bundled) via main.tsx
+      // and stores/auth.ts, so a dynamic import here bought no code-splitting —
+      // it only added an extra microtask hop before every error report.
+      if (options?.context || options?.data) {
+        setContext('logger', {
+          context: options?.context,
+          data: options?.data,
+        });
+      }
 
-        // Capture the exception
-        if (error instanceof Error) {
-          captureException(error, { message });
-        } else {
-          captureException(new Error(message), { originalError: error });
-        }
-      });
+      if (error instanceof Error) {
+        captureException(error, { message });
+      } else {
+        captureException(new Error(message), { originalError: error });
+      }
     } catch (err) {
       // Fail silently - don't break the app if Sentry fails
       console.warn('Failed to send error to Sentry:', err);


### PR DESCRIPTION
## Summary
Phase 1 of the performance/stability roadmap. Sentry was fully instrumented (browserTracing + replay) but almost nothing in application code actually reported to it:

- `main.tsx`'s global `QueryCache`/`MutationCache` `onError` handlers — the single choke point for essentially all Supabase query/mutation failures — only toasted + set an in-app health flag, never called `captureException`.
- `ErrorHandler.logError` always passed `undefined` as the error argument into `logger.error(...)`, and `logger.error`'s Sentry dispatch is gated on that argument being truthy — so it silently never fired. `ErrorBoundary`'s `componentDidCatch` routes through this exact path, so React render crashes were console-logged only.
- Fixed by reconstructing a real `Error` from `AppError`'s stored message/stack (the original `Error` instance isn't retained anywhere in `AppError`) and dispatching it on exactly one of `logError`'s four log lines — not all four, which would have spammed 4 duplicate Sentry events per single logical error.
- `logger.ts` dynamically imported `sentry.ts` "to avoid bundling Sentry in development," but `sentry.ts` is already statically imported by `main.tsx` and `stores/auth.ts` — the dynamic import bought zero code-splitting, just an extra microtask hop before every error report. Switched to static.

Net effect before this PR: the team had near-zero real-time visibility into what's actually breaking for users in production.

## Testing
- `tsc --noEmit`: 0 errors
- `npm run build`: green, no circular-import/bundling issue from the static-import switch (vendor chunk size unchanged, as expected — that's Phase 5)
- `vitest run`: 31 passed, 0 new failures (5 pre-existing integration suites fail locally without `VITE_TEST_EMAIL`/`PASSWORD`, unrelated — same as every prior PR this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)