### PR TITLE
fix(ci): path-filter e2e's job steps instead of its trigger

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,15 +1,16 @@
 name: E2E Tests
-# NOTE: path-filtered pull_request triggers mean this required check never
-# reports for PRs outside apps/web|packages/shared|this file, permanently
-# blocking merge for e.g. workflow-only PRs. Tracked for a proper fix.
+# This workflow always triggers (no path filter on `on:`) so the `e2e`
+# required status check always reports for every PR — path-filtering the
+# *trigger* meant PRs outside apps/web|packages/shared|this file never got
+# an e2e run at all, and branch protection then blocks merge forever
+# waiting on a check that will never arrive. Instead we path-filter inside
+# the job: the "Detect relevant changes" step decides whether the real
+# suite needs to run, and every step after it is skipped (not failed) when
+# it doesn't — so irrelevant PRs still get a fast, real "success".
 
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'apps/web/**'
-      - 'packages/shared/**'
-      - '.github/workflows/e2e.yml'
   workflow_dispatch:
 
 # The suite seeds and mutates a single shared Supabase database; two runs
@@ -27,18 +28,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -qE '^(apps/web/|packages/shared/|\.github/workflows/e2e\.yml)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        if: steps.changes.outputs.relevant == 'true'
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        if: steps.changes.outputs.relevant == 'true'
         run: npm ci
 
       - name: Build check
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: apps/web
         env:
           VITE_BACKEND: supabase
@@ -47,10 +68,12 @@ jobs:
         run: npm run build
 
       - name: Install Playwright Browsers
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: apps/web
         run: npx playwright install --with-deps
 
       - name: Start Vite dev server
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: apps/web
         env:
           VITE_BACKEND: supabase
@@ -60,25 +83,30 @@ jobs:
           nohup npm run dev -- --port 3002 > server.log 2>&1 &
 
       - name: Wait for dev server
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: apps/web
         run: npx wait-on@7.0.1 http://localhost:3002
 
       - name: Seed test database
+        if: steps.changes.outputs.relevant == 'true'
         env:
           SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_KEY }}
         run: node scripts/seed-with-credentials.js
 
       - name: Debug BASE_URL and /login HTML
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           echo "BASE_URL=$BASE_URL"
           curl -sS -D - "$BASE_URL/login" | head -n 80
 
       - name: Ensure BASE_URL visible to Playwright
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: apps/web
         run: node -e "console.log('Playwright sees BASE_URL=', process.env.BASE_URL)"
 
       - name: Run E2E tests
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: apps/web
         env:
           E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}


### PR DESCRIPTION
## Summary
Fixes the structural gap flagged (and worked around twice today) in #80 and #84: `e2e` is a required status check, but its trigger was path-filtered to `apps/web/**`, `packages/shared/**`, and this file — so any PR outside those paths (DB-only migrations, other workflow files, docs) never got an `e2e` run at all, and branch protection then blocked merge forever waiting on a check that would never arrive.

Fix: the workflow now always triggers (no path filter on `on:`), but a new "Detect relevant changes" step diffs the PR's base..head commits and sets `relevant=true/false`. Every step after it (Setup Node, install, build, browsers, dev server, seed, run tests) is conditioned on that output — **skipped, not failed**, when nothing relevant changed. An irrelevant PR now gets a real, fast "success" instead of an eternally pending check.

Also bumps `actions/setup-node` v4→v6 (same node20-runtime deprecation fix already applied to the other two workflows today) and adds `fetch-depth: 0` to checkout so the diff step has the base commit to compare against.

## Testing
- Verified the diff-detection regex locally against two scenarios: a DB-only file list → `relevant=false`; a list including `.github/workflows/e2e.yml` → `relevant=true`.
- This PR itself only touches `.github/workflows/e2e.yml`, which matches the "relevant" pattern — so its own CI run is a live end-to-end test of the fix: it should trigger and run the **full** suite, not skip.
- Bash syntax validated (`bash -n`) for the embedded shell logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)