### PR TITLE
perf(bundle): scope manualChunks instead of force-merging everything into vendor

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -65,14 +65,18 @@ export default defineConfig(({ mode }) => ({
     rollupOptions: {
       output: {
         manualChunks: (id) => {
-          // All node_modules in vendor chunk to avoid circular dependencies
-          if (id.includes('node_modules')) {
-            // Separate out large chart library
-            if (id.includes('recharts')) {
-              return 'charts'
-            }
-            return 'vendor'
-          }
+          if (!id.includes('node_modules')) return undefined
+          // Route-isolated heavy libs get their own chunk so they're only
+          // fetched when a route that actually uses them is visited —
+          // previously everything below was force-merged into one eager
+          // ~8.7MB 'vendor' chunk loaded on every page. Everything else
+          // (react, supabase-js, date-fns, sentry, etc.) falls through to
+          // Rollup's default per-entry-point chunking, return undefined.
+          if (id.includes('ag-grid')) return 'ag-grid'
+          if (id.includes('plotly')) return 'plotly'
+          if (id.includes('jspdf') || id.includes('exceljs')) return 'export-libs'
+          if (id.includes('recharts')) return 'charts'
+          return undefined
         },
         // Ensure consistent asset naming
         assetFileNames: 'assets/[name]-[hash][extname]',


### PR DESCRIPTION
## Summary
Phase 5 of the performance/stability roadmap — the highest raw performance impact in the whole plan, and the one flagged as needing careful manual verification (build-green alone doesn't prove runtime chunk-loading works).

Root cause of the long-flagged ~8.5MB vendor chunk: `apps/web/vite.config.ts`'s `manualChunks` force-merged every `node_modules` dependency (except `recharts`) into one `vendor` chunk, unconditionally `modulepreload`ed on every page load — even though routes ARE correctly lazy-loaded via `React.lazy()`. The catch-all was overriding Rollup's automatic per-route splitting entirely.

The existing comment ("avoid circular dependencies") is a real historical clue — someone hit an actual chunk-circularity bug before and worked around it by collapsing everything. So this doesn't blindly delete the catch-all: the confirmed route-isolated heavy libs (`ag-grid-community`/`ag-grid-react`, `plotly.js`/`react-plotly.js`, `jspdf`/`jspdf-autotable`/`exceljs`) get their own named chunks, the existing `recharts` → `charts` carve-out stays, and everything else falls through to Rollup's default per-entry-point chunking.

**Result**: the single 8.75MB/2.6MB-gzip vendor chunk is gone entirely. Heavy libs only load when a route that needs them is visited — `ag-grid` 1.34MB, `export-libs` 1.36MB, `plotly` 4.86MB, `charts` 420KB — versus the old unconditional 8.75MB on every page load regardless of route.

## Testing (verification was explicitly not optional for this change)
- `npm run build`: succeeds, **no circular-dependency errors** resurfaced.
- Full manual click-through of every lazy route via Playwright against the **production preview build** (`localhost:4173`, not dev mode — manualChunks only matters in production builds) — zero genuine chunk-load errors ("Failed to fetch dynamically imported module" / "Loading chunk failed") across multiple runs.
- Targeted verification of `/analytics` (the one route touching all three newly-split heavy libs at once via `ag-grid`, `recharts`, `export-libs`) — screenshot confirms full correct rendering (KPI cards, chart section containers, navigation all present; empty chart bodies are due to zero seeded audit data, not a load failure).
- `vitest run`: 31 passed, 0 new failures (5 pre-existing integration suites fail locally without test env vars — unrelated, same as every prior PR).
- `tsc --noEmit`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)