### PR TITLE
fix(surveys): await schedule-weekly-audits reconciliation, surface failures

### DIFF
--- a/apps/web/src/screens/ManageSurveyTemplates.tsx
+++ b/apps/web/src/screens/ManageSurveyTemplates.tsx
@@ -12,6 +12,7 @@ import { ClipboardDocumentListIcon, CheckCircleIcon, FolderIcon } from '@heroico
 import { useToast } from '../hooks/useToast'
 import { useOrganization } from '../contexts/OrganizationContext'
 import { getSupabase, hasSupabaseEnv } from '../utils/supabaseClient'
+import { logger } from '../utils/logger'
 
 const ManageSurveyTemplates: React.FC = () => {
   const navigate = useNavigate()
@@ -103,26 +104,33 @@ const ManageSurveyTemplates: React.FC = () => {
 
   const updateFrequencyMutation = useMutation({
     mutationFn: (payload: { id: string; frequency: AuditFrequency }) => (api as any).updateSurvey(payload.id, { frequency: payload.frequency }, effectiveOrgId),
-    onSuccess: (_result, variables) => {
+    onSuccess: async (_result, variables) => {
       queryClient.invalidateQueries({ queryKey: ['surveys', effectiveOrgId] })
       const survey = surveys.find(s => s.id === variables.id)
-      showToast({ 
-        message: `Survey "${survey?.title || 'Survey'}" frequency updated!`, 
-        variant: 'success' 
+      showToast({
+        message: `Survey "${survey?.title || 'Survey'}" frequency updated!`,
+        variant: 'success'
       })
       // Invoke the scheduler to reconcile for this survey immediately (best effort)
-      try {
-        if (hasSupabaseEnv()) {
+      if (hasSupabaseEnv()) {
+        try {
           const supabase = getSupabase()
           const anon = (import.meta as any).env.VITE_SUPABASE_ANON_KEY as string | undefined
-          void supabase.functions.invoke('schedule-weekly-audits', {
+          const { error } = await supabase.functions.invoke('schedule-weekly-audits', {
             body: { survey_id: variables.id },
             headers: anon ? { Authorization: `Bearer ${anon}` } : undefined,
           })
+          if (error) throw error
           // Refresh audits in dashboards after scheduling
           queryClient.invalidateQueries({ queryKey: QK.AUDITS('admin') })
+        } catch (e) {
+          logger.warn('schedule-weekly-audits invoke failed', { context: 'updateFrequencyMutation', data: e })
+          showToast({
+            message: 'Frequency updated, but the audit schedule may take a bit longer to refresh.',
+            variant: 'warning',
+          })
         }
-      } catch {}
+      }
     },
     onError: (error) => {
       showToast({ 


### PR DESCRIPTION
## Summary
Phase 8 (part 8.3) of the ongoing performance/stability roadmap — split from #92 because this one is a genuine behavior change, not purely additive.

`ManageSurveyTemplates.tsx`'s `updateFrequencyMutation.onSuccess` fired the scheduler reconciliation (`schedule-weekly-audits` edge function) as `void supabase.functions.invoke(...)` wrapped in an empty `catch {}` — a failure was completely invisible, and the `QK.AUDITS('admin')` cache invalidation ran unconditionally in the same block regardless of whether the invoke actually happened or failed.

Now: the call is awaited, its `error` is checked, and:
- **Success**: audits list still refreshes (unchanged behavior).
- **Failure**: the frequency-change success toast already shown stands (the actual DB update succeeded), a follow-up warning toast tells the user the schedule refresh may lag, and `logger.warn` makes the failure visible instead of silent.

## Risk
Low, but flagged as a real behavior change per the roadmap (not bundled with the purely-additive Phase 8 PR, #92): the mutation's `onSuccess` handler is now `async`, and a second toast can now appear after the success toast on the (rare) failure path.

## Verification
- `tsc --noEmit`: 0 errors.
- Manually reviewed both branches (success/failure) against the original fire-and-forget behavior — success path is byte-for-byte the same; only the failure path gains visibility.

## Test plan
- [ ] CI `checks` green
- [ ] CI `e2e` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
