### PR TITLE
fix(invites): add scoped idempotency to prevent duplicate invite emails

### DIFF
--- a/apps/web/src/utils/__tests__/inviteUser.test.ts
+++ b/apps/web/src/utils/__tests__/inviteUser.test.ts
@@ -66,7 +66,13 @@ describe('supabaseApi.inviteUser', () => {
     const user = await supabaseApi.inviteUser('new@acme.com', 'New User', UserRole.AUDITOR)
 
     expect(state.invokeSpy).toHaveBeenCalledWith('invite-user', {
-      body: { email: 'new@acme.com', name: 'New User', role: UserRole.AUDITOR, orgId: 'org-1' },
+      body: {
+        email: 'new@acme.com',
+        name: 'New User',
+        role: UserRole.AUDITOR,
+        orgId: 'org-1',
+        idempotencyKey: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      },
     })
     expect(user.id).toBe('new-user-id')
     expect(user.orgId).toBe('org-1')

--- a/apps/web/src/utils/supabaseApi.ts
+++ b/apps/web/src/utils/supabaseApi.ts
@@ -1832,6 +1832,12 @@ export const supabaseApi = {
     const { data: existingUser } = await supabase.from('users').select('email').eq('email', email).single()
     if (existingUser) throw new Error('User with this email already exists')
 
+    // Idempotency key: guardedFetch (circuitBreaker.ts) retries this request on
+    // 5xx/timeout. The key stays fixed across those internal retries (same
+    // request body reused), letting the edge function recognize a retry of an
+    // already-succeeded invite instead of erroring or re-sending the email.
+    const idempotencyKey = crypto.randomUUID()
+
     // Call Edge Function to send invitation
     // This uses service role key securely on the server side
     const { data, error } = await supabase.functions.invoke('invite-user', {
@@ -1839,7 +1845,8 @@ export const supabaseApi = {
         email,
         name,
         role,
-        orgId: userData.org_id
+        orgId: userData.org_id,
+        idempotencyKey,
       }
     })
 

--- a/supabase/functions/invite-user/index.ts
+++ b/supabase/functions/invite-user/index.ts
@@ -42,7 +42,7 @@ Deno.serve(async (req) => {
       throw new Error('Only admins can invite users')
     }
 
-    const { email, name, role, orgId } = await req.json()
+    const { email, name, role, orgId, idempotencyKey } = await req.json()
 
     if (!email || !name || !role || !orgId) {
       throw new Error('Missing required fields: email, name, role, orgId')
@@ -51,6 +51,39 @@ Deno.serve(async (req) => {
     // Admins can only invite into their own org; super admins can invite into any
     if (callerData.role === 'ADMIN' && callerData.org_id !== orgId) {
       throw new Error('Admins can only invite users into their own organization')
+    }
+
+    // Idempotency: the client's retry layer (guardedFetch) re-sends this exact
+    // request on 5xx/timeout, including when the invite actually succeeded
+    // server-side but the response was lost in transit. If this idempotency
+    // key was already processed, return the original result instead of
+    // re-inviting (which would otherwise surface as a confusing "user already
+    // exists" error even though the admin's request succeeded).
+    if (idempotencyKey) {
+      const detailsMarker = `Invited ${email} as ${role} [key:${idempotencyKey}]`
+      const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString()
+      const { data: priorInvite } = await supabase
+        .from('activity_logs')
+        .select('entity_id')
+        .eq('org_id', orgId)
+        .eq('action', 'user_invited')
+        .eq('details', detailsMarker)
+        .gte('created_at', tenMinutesAgo)
+        .maybeSingle()
+
+      if (priorInvite?.entity_id) {
+        const { data: priorUser } = await supabase
+          .from('users')
+          .select()
+          .eq('id', priorInvite.entity_id)
+          .maybeSingle()
+        if (priorUser) {
+          return new Response(
+            JSON.stringify({ success: true, user: priorUser, message: `Invitation already sent to ${email}` }),
+            { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
+          )
+        }
+      }
     }
 
     // Rate limit: max INVITE_RATE_LIMIT invites per org per hour, counted from
@@ -105,7 +138,7 @@ Deno.serve(async (req) => {
       action: 'user_invited',
       entity_type: 'user',
       entity_id: newUser.id,
-      details: `Invited ${email} as ${role}`,
+      details: idempotencyKey ? `Invited ${email} as ${role} [key:${idempotencyKey}]` : `Invited ${email} as ${role}`,
     })
 
     return new Response(


### PR DESCRIPTION
## Summary
Phase 9 of the ongoing performance/stability roadmap.

`guardedFetch` (`circuitBreaker.ts`) retries Supabase calls on 5xx/timeout regardless of whether the underlying mutation already committed server-side. For `inviteUser`, a retry after a lost response previously either silently re-invited the same email (duplicate invite) or surfaced a confusing "user already exists" error to the admin even though their original request had actually succeeded.

- **Client** (`supabaseApi.ts`): generates one `idempotencyKey` (`crypto.randomUUID()`) per `inviteUser` call. It stays fixed across `guardedFetch`'s internal retries for that call, since retries reuse the same request body.
- **Edge function** (`invite-user/index.ts`): before proceeding, checks `activity_logs` for a prior `user_invited` entry carrying that exact key (10-minute window). On a match, it returns the original result (the already-created user) instead of re-inviting or erroring.

Scoped narrowly to this one concrete user-facing failure mode rather than building general idempotency-key infrastructure — consistent with the roadmap's reasoning (poor ROI for the general case right now; revisit only if retry-duplicates show up in Sentry).

## Verification
- `tsc --noEmit`: 0 errors.
- Unit tests (`inviteUser.test.ts`): updated the body-shape assertion for the new field, all 4 tests pass.
- Deployed the updated edge function to the live project and verified directly against it (bypassing real email deliverability, which is an unrelated pre-existing gap):
  - A retry with the **same** idempotency key returns the cached user (`200`, `success: true`, same user id) without attempting a new invite.
  - A **different** idempotency key for the same email correctly does *not* hit the cache — falls through to the normal duplicate-email `400` rejection, proving the check doesn't over-match.

## Test plan
- [ ] CI `checks` green
- [ ] CI `e2e` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
