### PR TITLE
test: backfill e2e coverage for resubmit cycle, bulk ops, and exports

### DIFF
--- a/apps/web/tests/audit.approval-flow.spec.ts
+++ b/apps/web/tests/audit.approval-flow.spec.ts
@@ -7,6 +7,8 @@ import {
   ensureBranchManagerAssigned,
   ensureAuditFor,
   setAuditSubmitted,
+  setAuditRejected,
+  getFirstQuestionId,
   getAuditStatus,
   deleteAudits,
   getUserClient,
@@ -20,6 +22,7 @@ test.describe('Audit approval workflow', () => {
   let orgId: string
   let branchId: string
   let surveyId: string
+  let questionId: string
   let auditorId: string
   let managerId: string
 
@@ -40,6 +43,7 @@ test.describe('Audit approval workflow', () => {
     branchId = branch.id
     const survey = await ensureSimpleSurvey(orgId, 'E2E Approval Survey')
     surveyId = survey.id
+    questionId = await getFirstQuestionId(surveyId)
 
     await ensureAuditorAssignedToBranch(auditorId, branchId)
     await ensureBranchManagerAssigned(managerId, branchId)
@@ -69,6 +73,28 @@ test.describe('Audit approval workflow', () => {
       // fall through to credentials
     }
     await page.fill('input[type="email"]', 'branchmanager@trakr.com')
+    await page.fill('input[type="password"]', 'Password@123')
+    await page.getByRole('button', { name: /Sign in|Log in/i }).click()
+    await page.waitForURL(url => url.pathname.includes('/dashboard'), { timeout: 30_000 })
+  }
+
+  async function loginAsAuditor(page: Page) {
+    await page.goto('/login')
+    await page.context().clearCookies()
+    await page.evaluate(() => localStorage.clear())
+    await page.goto('/login', { waitUntil: 'networkidle' })
+
+    try {
+      const roleButton = page.getByRole('button', { name: /^Auditor/i }).first()
+      if (await roleButton.isVisible({ timeout: 5_000 })) {
+        await roleButton.click()
+        await page.waitForURL(url => url.pathname.includes('/dashboard'), { timeout: 30_000 })
+        return
+      }
+    } catch {
+      // fall through to credentials
+    }
+    await page.fill('input[type="email"]', 'auditor@trakr.com')
     await page.fill('input[type="password"]', 'Password@123')
     await page.getByRole('button', { name: /Sign in|Log in/i }).click()
     await page.waitForURL(url => url.pathname.includes('/dashboard'), { timeout: 30_000 })
@@ -163,5 +189,67 @@ test.describe('Audit approval workflow', () => {
     // The first approval's data must be untouched by the rejected second call.
     const status = await getAuditStatus(auditId)
     expect(status).toBe('APPROVED')
+  })
+
+  test('full cycle: auditor edits a rejected audit, resubmits, and manager approves it', async ({ page, browser }) => {
+    // Only SUBMITTED→APPROVED/REJECTED are covered above. This exercises the
+    // other half of the lifecycle: an auditor recovering from a REJECTED
+    // audit by editing their answer in the wizard and resubmitting, then a
+    // manager approving that resubmission — the path a real rejection cycle
+    // actually takes, not just the two terminal transitions in isolation.
+    test.setTimeout(180_000)
+
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId, { [questionId]: 'yes' })
+    createdAuditIds.push(audit.id)
+    await setAuditRejected(audit.id, managerId, 'Please double-check the fire exit photo.')
+
+    // Auditor edits the flagged answer and resubmits via the wizard.
+    await loginAsAuditor(page)
+    await page.goto(`/audit/${audit.id}/wizard`, { waitUntil: 'networkidle' })
+
+    const noAnswer = page.getByTestId(`answer-${questionId}-no`)
+    await expect(noAnswer).toBeVisible({ timeout: 20_000 })
+    await noAnswer.click()
+
+    // Two "finish-audit" buttons render (mobile-only + desktop-only responsive
+    // variants); at the default desktop viewport only the second is visible.
+    const finishButton = page.getByTestId('finish-audit').last()
+    await expect(finishButton).toBeEnabled({ timeout: 10_000 })
+    await finishButton.click()
+
+    await page.waitForURL(url => url.pathname.includes(`/audit/${audit.id}/summary`) || url.pathname.includes(`/audits/${audit.id}/summary`), { timeout: 30_000 })
+
+    const submitButton = page.getByTestId('submit-for-approval')
+    await expect(submitButton).toBeEnabled({ timeout: 20_000 })
+    await submitButton.click()
+
+    await expect
+      .poll(async () => getAuditStatus(audit.id), { timeout: 30_000, intervals: [1_000] })
+      .toBe('SUBMITTED')
+
+    // Manager approves the resubmission — a fresh browser context, not the
+    // auditor's page, since switching authenticated users mid-test on the
+    // same page raced with in-flight session/redirect state during manual
+    // verification.
+    const managerContext = await browser.newContext()
+    const managerPage = await managerContext.newPage()
+    try {
+      await loginAsBranchManager(managerPage)
+      await managerPage.goto(`/audits/${audit.id}/summary`, { waitUntil: 'networkidle' })
+
+      const approveButton = managerPage.getByRole('button', { name: /Approve/i }).first()
+      await expect(approveButton).toBeVisible({ timeout: 20_000 })
+      await approveButton.click()
+      const modal = managerPage.getByRole('dialog')
+      await expect(modal).toBeVisible({ timeout: 10_000 })
+      await modal.getByPlaceholder(/Jane Manager/i).fill('Approved After Resubmission')
+      await modal.getByRole('button', { name: /^Approve|Approving/i }).click()
+
+      await expect
+        .poll(async () => getAuditStatus(audit.id), { timeout: 30_000, intervals: [1_000] })
+        .toBe('APPROVED')
+    } finally {
+      await managerContext.close()
+    }
   })
 })

--- a/apps/web/tests/bulk-operations.spec.ts
+++ b/apps/web/tests/bulk-operations.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { loginAsAdmin } from './helpers/auth'
+import { loginAsAdmin, switchToOrganization } from './helpers/auth'
 import {
   getUserByEmail,
   ensureZoneForOrg,
@@ -27,11 +27,19 @@ test.describe('Bulk operations', () => {
   let auditorId: string
 
   test.beforeAll(async () => {
-    const admin = await getUserByEmail('admin@trakr.com')
     const auditor = await getUserByEmail('auditor@trakr.com')
-    if (!admin || !auditor) throw new Error('Seed users missing')
-    if (!admin.org_id) throw new Error('admin@trakr.com has no org_id')
-    orgId = admin.org_id
+    if (!auditor) throw new Error('Seed users missing')
+    if (!auditor.org_id) throw new Error('auditor@trakr.com has no org_id')
+    // admin@trakr.com is SUPER_ADMIN, not a regular admin: a fresh login has
+    // no stored org preference, so it defaults to whichever org is oldest by
+    // created_at (OrganizationContext.tsx) — the live dev DB has stale
+    // duplicate-named orgs left over from seeding, so "oldest" isn't
+    // guaranteed to be the org the fixed seed accounts actually belong to.
+    // Derive orgId from the auditor's own row instead, and explicitly
+    // switch the admin session to it via switchToOrganization() below —
+    // this needs the auditor to actually be a member of the org for the
+    // zone-assignment checklist to list them.
+    orgId = auditor.org_id
     auditorId = auditor.id
   })
 
@@ -42,6 +50,7 @@ test.describe('Bulk operations', () => {
 
     try {
       await loginAsAdmin(page)
+      await switchToOrganization(page, orgId)
       await page.goto('/manage/branches', { waitUntil: 'networkidle' })
 
       await page.getByRole('button', { name: /Bulk Assign by Zone/i }).click()
@@ -93,6 +102,7 @@ test.describe('Bulk operations', () => {
       expect(await getBranchActive(branchB.id)).toBe(false)
 
       await loginAsAdmin(page)
+      await switchToOrganization(page, orgId)
       await page.goto('/manage/branches', { waitUntil: 'networkidle' })
 
       // The button's accessible name comes from an aria-label that differs
@@ -102,7 +112,13 @@ test.describe('Bulk operations', () => {
       await expect(activateButton).toBeEnabled({ timeout: 20_000 })
       await activateButton.click()
 
-      await expect(page.getByText(/Activated \d+ branch/i)).toBeVisible({ timeout: 20_000 })
+      // toast reads "Activated N branch(es). M failed." when some updates
+      // are rejected — /Activated \d+ branch/i alone would still match a
+      // "Activated 0 branches. 2 failed." partial-failure message, so also
+      // assert the failure clause is absent.
+      const toast = page.getByText(/Activated \d+ branch/i)
+      await expect(toast).toBeVisible({ timeout: 20_000 })
+      await expect(toast).not.toContainText(/failed/i)
 
       await expect.poll(async () => getBranchActive(branchA.id), { timeout: 15_000, intervals: [1_000] }).toBe(true)
       await expect.poll(async () => getBranchActive(branchB.id), { timeout: 15_000, intervals: [1_000] }).toBe(true)

--- a/apps/web/tests/bulk-operations.spec.ts
+++ b/apps/web/tests/bulk-operations.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from './helpers/auth'
+import {
+  getUserByEmail,
+  ensureZoneForOrg,
+  createInactiveBranch,
+  linkBranchToZone,
+  deleteBranches,
+  getBranchActive,
+  setAuditorAssignmentDirect,
+  getAuditorAssignmentBranchIds,
+} from './helpers/e2eSetup'
+
+// Bulk operations on /manage/branches: zone-based bulk auditor assignment
+// and one-click bulk branch activation. Both previously had zero e2e
+// coverage despite mutating many rows in a single user action.
+//
+// Setup/teardown here is additive-only against the shared auditor_assignments
+// row (never clears or replaces it) — the account is shared with other spec
+// files and a DB-level guard rejects unassigning an auditor from any branch
+// that's currently active, so a naive "reset to empty" can fail outright or
+// clobber fixtures that legitimately belong to other tests.
+test.describe('Bulk operations', () => {
+  test.setTimeout(60_000)
+
+  let orgId: string
+  let auditorId: string
+
+  test.beforeAll(async () => {
+    const admin = await getUserByEmail('admin@trakr.com')
+    const auditor = await getUserByEmail('auditor@trakr.com')
+    if (!admin || !auditor) throw new Error('Seed users missing')
+    if (!admin.org_id) throw new Error('admin@trakr.com has no org_id')
+    orgId = admin.org_id
+    auditorId = auditor.id
+  })
+
+  test('admin can bulk-assign an auditor to every branch in a zone', async ({ page }) => {
+    const zone = await ensureZoneForOrg(orgId, 'E2E Bulk Zone')
+    const branch = await createInactiveBranch(orgId, 'E2E Bulk-Assign Branch')
+    await linkBranchToZone(zone.id, branch.id)
+
+    try {
+      await loginAsAdmin(page)
+      await page.goto('/manage/branches', { waitUntil: 'networkidle' })
+
+      await page.getByRole('button', { name: /Bulk Assign by Zone/i }).click()
+
+      // The page also has a static "Bulk Assign Auditors by Zone" card
+      // heading behind the modal, so anchor on the zone <select> (unique to
+      // the modal) rather than the ambiguous shared heading text — matching
+      // on the heading with .last() breaks once the modal closes, since
+      // .last() then re-resolves to the ever-present static card heading.
+      const zoneSelect = page.locator('select').filter({ has: page.locator('option', { hasText: 'Choose a zone' }) })
+      await expect(zoneSelect).toBeVisible({ timeout: 10_000 })
+      await zoneSelect.selectOption({ value: zone.id })
+
+      // Matched by email, not name: the seed data has several similarly-named
+      // auditors ("Auditor1", "Auditor2", ...) and the target account's own
+      // display name is just "Auditor".
+      const auditorRow = page.locator('label').filter({ hasText: 'auditor@trakr.com' }).first()
+      await expect(auditorRow).toBeVisible({ timeout: 10_000 })
+      await auditorRow.locator('input[type="checkbox"]').check()
+
+      await page.getByRole('button', { name: /Assign \d+ to Zone/i }).click()
+
+      // Modal closes on success (onClose is called from the mutation's onSuccess)
+      await expect(zoneSelect).not.toBeVisible({ timeout: 15_000 })
+
+      await expect
+        .poll(async () => getAuditorAssignmentBranchIds(auditorId), { timeout: 15_000, intervals: [1_000] })
+        .toContain(branch.id)
+    } finally {
+      // Deliberately not unassigning branch.id from the auditor first: it's
+      // never activated in this test, so the delete below leaves at most a
+      // harmless dangling id in auditor_assignments.branch_ids (no FK there).
+      await deleteBranches([branch.id])
+    }
+  })
+
+  test('admin can bulk-activate all eligible branches at once', async ({ page }) => {
+    const branchA = await createInactiveBranch(orgId, 'E2E Bulk-Activate A')
+    const branchB = await createInactiveBranch(orgId, 'E2E Bulk-Activate B')
+    // Eligibility requires at least one assigned auditor per branch, read
+    // from auditor_assignments (see setAuditorAssignmentDirect for why this
+    // isn't the same table the assignment-board RPC writes to). Additive:
+    // keep whatever the shared account was already assigned to.
+    const existing = await getAuditorAssignmentBranchIds(auditorId)
+    await setAuditorAssignmentDirect(auditorId, orgId, [...new Set([...existing, branchA.id, branchB.id])], [])
+
+    try {
+      expect(await getBranchActive(branchA.id)).toBe(false)
+      expect(await getBranchActive(branchB.id)).toBe(false)
+
+      await loginAsAdmin(page)
+      await page.goto('/manage/branches', { waitUntil: 'networkidle' })
+
+      // The button's accessible name comes from an aria-label that differs
+      // from its visible "Activate All Eligible" text ("Activate N eligible
+      // branches" when enabled, "No eligible branches to activate" when not).
+      const activateButton = page.getByRole('button', { name: /Activate \d+ eligible branch/i })
+      await expect(activateButton).toBeEnabled({ timeout: 20_000 })
+      await activateButton.click()
+
+      await expect(page.getByText(/Activated \d+ branch/i)).toBeVisible({ timeout: 20_000 })
+
+      await expect.poll(async () => getBranchActive(branchA.id), { timeout: 15_000, intervals: [1_000] }).toBe(true)
+      await expect.poll(async () => getBranchActive(branchB.id), { timeout: 15_000, intervals: [1_000] }).toBe(true)
+    } finally {
+      // Both branches just got activated by the test itself, so touching
+      // auditor_assignments here would hit the "can't remove auditor from an
+      // active branch" DB trigger. That trigger only fires on updates to
+      // auditor_assignments, not on deleting the branch row itself, so just
+      // delete the branches and leave the now-dangling (harmless, no FK) ids
+      // in auditor_assignments.branch_ids.
+      await deleteBranches([branchA.id, branchB.id])
+    }
+  })
+})

--- a/apps/web/tests/export-paths.spec.ts
+++ b/apps/web/tests/export-paths.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from './helpers/auth'
+import {
+  getUserByEmail,
+  ensureBranchForOrg,
+  ensureSimpleSurvey,
+  getFirstQuestionId,
+  ensureAuditFor,
+  setAuditApproved,
+  deleteAudits,
+} from './helpers/e2eSetup'
+
+// Survey results export (CSV/Excel/PDF) on /analytics's Reports tab
+// (AdvancedAnalyticsComplete.tsx -> utils/exportUtils.ts) had zero e2e
+// coverage despite being a common report-out workflow for admins.
+test.describe('Export paths', () => {
+  test.setTimeout(60_000)
+
+  let orgId: string
+  let branchId: string
+  let surveyId: string
+  let questionId: string
+  let auditorId: string
+  let managerId: string
+
+  test.beforeAll(async () => {
+    const admin = await getUserByEmail('admin@trakr.com')
+    const auditor = await getUserByEmail('auditor@trakr.com')
+    if (!admin || !auditor) throw new Error('Seed users missing')
+    if (!admin.org_id) throw new Error('admin@trakr.com has no org_id')
+    orgId = admin.org_id
+    auditorId = auditor.id
+    managerId = admin.id
+
+    const branch = await ensureBranchForOrg(orgId, 'E2E Export Branch')
+    branchId = branch.id
+    const survey = await ensureSimpleSurvey(orgId, 'E2E Export Survey')
+    surveyId = survey.id
+    questionId = await getFirstQuestionId(surveyId)
+  })
+
+  const createdAuditIds: string[] = []
+
+  test.afterAll(async () => {
+    await deleteAudits(createdAuditIds)
+  })
+
+  test('admin can export survey results as CSV, Excel, and PDF', async ({ page }) => {
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId, { [questionId]: 'yes' })
+    createdAuditIds.push(audit.id)
+    await setAuditApproved(audit.id, managerId)
+
+    await loginAsAdmin(page)
+    await page.goto('/analytics', { waitUntil: 'networkidle' })
+
+    await page.getByRole('button', { name: /Reports/i }).click()
+
+    const surveySelect = page.locator('select').filter({ has: page.locator(`option[value="${surveyId}"]`) })
+    await expect(surveySelect).toBeVisible({ timeout: 15_000 })
+    await surveySelect.selectOption({ value: surveyId })
+
+    // Export buttons only render once results.length > 0 for the selected survey.
+    const exportCsvButton = page.getByRole('button', { name: /Export CSV/i })
+    await expect(exportCsvButton).toBeVisible({ timeout: 20_000 })
+
+    const [csvDownload] = await Promise.all([
+      page.waitForEvent('download'),
+      exportCsvButton.click(),
+    ])
+    expect(csvDownload.suggestedFilename()).toMatch(/\.csv$/i)
+
+    const [xlsxDownload] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: /Export Excel/i }).click(),
+    ])
+    expect(xlsxDownload.suggestedFilename()).toMatch(/\.xlsx$/i)
+
+    const [pdfDownload] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: /Export PDF/i }).click(),
+    ])
+    expect(pdfDownload.suggestedFilename()).toMatch(/\.pdf$/i)
+  })
+})

--- a/apps/web/tests/export-paths.spec.ts
+++ b/apps/web/tests/export-paths.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { loginAsAdmin } from './helpers/auth'
+import { loginAsAdmin, switchToOrganization } from './helpers/auth'
 import {
   getUserByEmail,
   ensureBranchForOrg,
@@ -27,8 +27,16 @@ test.describe('Export paths', () => {
     const admin = await getUserByEmail('admin@trakr.com')
     const auditor = await getUserByEmail('auditor@trakr.com')
     if (!admin || !auditor) throw new Error('Seed users missing')
-    if (!admin.org_id) throw new Error('admin@trakr.com has no org_id')
-    orgId = admin.org_id
+    if (!auditor.org_id) throw new Error('auditor@trakr.com has no org_id')
+    // admin@trakr.com is SUPER_ADMIN, not a regular admin: a fresh login has
+    // no stored org preference, so it defaults to whichever org is oldest by
+    // created_at (OrganizationContext.tsx) — the live dev DB has stale
+    // duplicate-named orgs left over from seeding, so "oldest" isn't
+    // guaranteed to be the org the fixed seed accounts actually belong to.
+    // Derive orgId from the auditor's own row instead, and explicitly switch
+    // the admin session to it via switchToOrganization() below. managerId is
+    // just an FK reference for approved_by, so admin.id itself is still fine.
+    orgId = auditor.org_id
     auditorId = auditor.id
     managerId = admin.id
 
@@ -51,6 +59,7 @@ test.describe('Export paths', () => {
     await setAuditApproved(audit.id, managerId)
 
     await loginAsAdmin(page)
+    await switchToOrganization(page, orgId)
     await page.goto('/analytics', { waitUntil: 'networkidle' })
 
     await page.getByRole('button', { name: /Reports/i }).click()

--- a/apps/web/tests/helpers/auth.ts
+++ b/apps/web/tests/helpers/auth.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 
 /**
  * Handle onboarding screen if it appears after login.
@@ -106,4 +106,29 @@ export async function loginAsAdmin(page: Page) {
   
   await page.waitForURL(url => url.pathname.includes('/dashboard') || url.pathname.includes('/onboarding'), { timeout: 60_000 })
   await handleOnboardingIfNeeded(page)
+}
+
+/**
+ * Explicitly select an organization via the super-admin org switcher on
+ * /settings (the only place it's actually rendered — the standalone
+ * OrganizationSwitcher.tsx component exists but is never mounted anywhere).
+ * A fresh admin login has no stored org preference, so OrganizationContext
+ * defaults currentOrg to whichever org is oldest by created_at — not
+ * necessarily the org any given fixture was created under (the live dev DB
+ * has stale duplicate-named orgs left over from seeding). Tests that create
+ * fixtures under a specific org must call this after loginAsAdmin() to
+ * guarantee the session is actually viewing that org. The selection is
+ * persisted to localStorage by switchOrganization(), so it survives the
+ * caller's subsequent navigation to whatever page it actually needs.
+ */
+export async function switchToOrganization(page: Page, orgId: string) {
+  await page.goto('/settings', { waitUntil: 'networkidle' })
+  // The org switcher lives under the "Super Admin" settings tab, not
+  // "Organization" (that one is org profile/branding) or the default
+  // "Profile" tab.
+  await page.getByRole('navigation', { name: /Settings tabs/i }).getByRole('button', { name: /^Super Admin$/i }).click()
+  const orgSelect = page.locator('select').filter({ has: page.locator('option', { hasText: 'Select Organization' }) })
+  await expect(orgSelect).toBeVisible({ timeout: 15_000 })
+  await orgSelect.selectOption({ value: orgId })
+  await expect(orgSelect).toHaveValue(orgId, { timeout: 10_000 })
 }

--- a/apps/web/tests/helpers/e2eSetup.ts
+++ b/apps/web/tests/helpers/e2eSetup.ts
@@ -115,6 +115,88 @@ export async function setAuditSubmitted(auditId: string, submittedBy: string) {
   if (error) throw error
 }
 
+export async function setAuditApproved(auditId: string, approvedBy: string) {
+  const supa = getAdminClient()
+  const { error } = await supa
+    .from('audits')
+    .update({
+      status: 'APPROVED',
+      approved_by: approvedBy,
+      approved_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as any)
+    .eq('id', auditId)
+  if (error) throw error
+}
+
+export async function setAuditRejected(auditId: string, rejectedBy: string, note = 'E2E rejection note') {
+  const supa = getAdminClient()
+  const { error } = await supa
+    .from('audits')
+    .update({
+      status: 'REJECTED',
+      rejected_by: rejectedBy,
+      rejected_at: new Date().toISOString(),
+      rejection_note: note,
+      updated_at: new Date().toISOString(),
+    } as any)
+    .eq('id', auditId)
+  if (error) throw error
+}
+
+export async function getFirstQuestionId(surveyId: string): Promise<string> {
+  const supa = getAdminClient()
+  const { data, error } = await supa
+    .from('survey_questions')
+    .select('id')
+    .eq('survey_id', surveyId)
+    .order('order_num', { ascending: true })
+    .limit(1)
+    .single()
+  if (error) throw error
+  return (data as any).id
+}
+
+// Always creates a fresh branch (unlike ensureBranchForOrg's reuse-by-prefix
+// behavior) so bulk-activation tests get a predictable, isolated eligible set
+// instead of possibly picking up an already-active branch from a prior run.
+export async function createInactiveBranch(orgId: string, nameHint = 'E2E Bulk Branch'): Promise<{ id: string; name: string }> {
+  const supa = getAdminClient()
+  const now = new Date().toISOString()
+  const name = `${nameHint} ${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+  const { data, error } = await supa.from('branches').insert({ org_id: orgId, name, address: 'Test Addr', is_active: false, created_at: now, updated_at: now } as any).select('*').single()
+  if (error) throw error
+  return { id: (data as any).id, name }
+}
+
+export async function linkBranchToZone(zoneId: string, branchId: string) {
+  const supa = getAdminClient()
+  const { error } = await supa.from('zone_branches').upsert({ zone_id: zoneId, branch_id: branchId } as any)
+  if (error) throw error
+}
+
+export async function getBranchActive(branchId: string): Promise<boolean | null> {
+  const supa = getAdminClient()
+  const { data, error } = await supa.from('branches').select('is_active').eq('id', branchId).maybeSingle()
+  if (error) throw error
+  return (data as any)?.is_active ?? null
+}
+
+export async function deleteBranches(branchIds: string[]) {
+  if (!branchIds.length) return
+  const supa = getAdminClient()
+  await supa.from('zone_branches').delete().in('branch_id', branchIds)
+  const { error } = await supa.from('branches').delete().in('id', branchIds)
+  if (error) throw error
+}
+
+export async function getAuditorAssignmentBranchIds(auditorId: string): Promise<string[]> {
+  const supa = getAdminClient()
+  const { data, error } = await supa.from('auditor_assignments').select('branch_ids').eq('user_id', auditorId).maybeSingle()
+  if (error) throw error
+  return (data as any)?.branch_ids || []
+}
+
 export async function deleteAudits(auditIds: string[]) {
   if (!auditIds.length) return
   const supa = getAdminClient()
@@ -139,7 +221,21 @@ export async function ensureAuditorAssignedToBranch(auditorUserId: string, branc
   if (error) throw error
 }
 
-export async function ensureAuditFor(auditorUserId: string, orgId: string, branchId: string, surveyId: string): Promise<{ id: string }> {
+// NOTE: set_auditor_assignment (above) writes to auditor_branch_assignments,
+// a period-scoped table used by the assignment-board/scheduling flows. The
+// ManageBranches "eligible to activate" and ZoneBulkAuditorAssignment UI
+// instead read/write the separate auditor_assignments table directly (see
+// supabaseApi.ts's setAuditorAssignment). Use this helper — not the RPC
+// above — when a test needs to match what those specific screens see.
+export async function setAuditorAssignmentDirect(auditorUserId: string, orgId: string, branchIds: string[], zoneIds: string[] = []) {
+  const supa = getAdminClient()
+  const { error } = await supa
+    .from('auditor_assignments')
+    .upsert({ user_id: auditorUserId, org_id: orgId, branch_ids: branchIds, zone_ids: zoneIds, updated_at: new Date().toISOString() } as any, { onConflict: 'user_id' })
+  if (error) throw error
+}
+
+export async function ensureAuditFor(auditorUserId: string, orgId: string, branchId: string, surveyId: string, responses: Record<string, string> = {}): Promise<{ id: string }> {
   const supa = getAdminClient()
   // Fetch survey version
   const { data: s, error: sErr } = await supa.from('surveys').select('id, version, frequency').eq('id', surveyId).maybeSingle()
@@ -154,7 +250,7 @@ export async function ensureAuditFor(auditorUserId: string, orgId: string, branc
     survey_version: (s as any).version ?? 1,
     assigned_to: auditorUserId,
     status: 'DRAFT',
-    responses: {},
+    responses,
     na_reasons: {},
     section_comments: {},
     created_at: now.toISOString(),


### PR DESCRIPTION
## Summary
Phase 10 (final phase) of the performance/stability roadmap — backfills three previously zero-coverage e2e gaps. Test-only, no application code changes.

- **`audit.approval-flow.spec.ts`**: adds the reject→edit→resubmit→approve full cycle. Only the two terminal `SUBMITTED→APPROVED`/`SUBMITTED→REJECTED` transitions were covered before, each in isolation. This drives an auditor through the wizard to fix a rejected answer and resubmit, then a manager approving the resubmission — the actual path a real rejection cycle takes in production.
- **`bulk-operations.spec.ts`** (new): zone-based bulk auditor assignment and one-click bulk branch activation on `/manage/branches` — both mutate many rows per action and had zero coverage. Along the way, discovered that `ManageBranches`' eligibility/assignment UI reads `auditor_assignments` directly, not the `auditor_branch_assignments` table the existing `set_auditor_assignment` RPC writes to (two separate, pre-existing assignment concepts in this codebase). Setup/teardown is additive-only against the shared seed auditor account — never clears or replaces its assignment — both to avoid clobbering other spec files' fixtures and to avoid a DB trigger that rejects unassigning an auditor from a currently-active branch.
- **`export-paths.spec.ts`** (new): CSV/Excel/PDF export from the Analytics "Reports" tab, previously untested. Verified via real browser downloads (`page.waitForEvent('download')`), not just that the button exists and is clickable.
- **`helpers/e2eSetup.ts`**: adds `setAuditRejected`, `setAuditApproved`, `getFirstQuestionId`, `createInactiveBranch`, `linkBranchToZone`, `getBranchActive`, `deleteBranches`, `getAuditorAssignmentBranchIds`, `setAuditorAssignmentDirect`, and extends `ensureAuditFor` with an optional seed-responses parameter. Every helper is used by at least one spec (verified — no dead code added).

## Verification
- `tsc --noEmit`: 0 errors.
- All 7 tests (4 in `audit.approval-flow.spec.ts`, 2 in `bulk-operations.spec.ts`, 1 in `export-paths.spec.ts`) run locally against the live dev DB and pass, including running concurrently across 3 workers.
- Along the way, found and fixed several real test-authoring bugs before finalizing (not app bugs): a `.last()` locator that silently re-resolved to the wrong element after a modal closed, an `aria-label` that overrides a button's visible text for accessibility-tree matching, and the `auditor_assignments` vs `auditor_branch_assignments` table mismatch above.

## Test plan
- [ ] CI `checks` green
- [ ] CI `e2e` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
