### PR TITLE
fix(seed): stop silently swallowing delete errors in seed script

### DIFF
--- a/scripts/seed-with-credentials.js
+++ b/scripts/seed-with-credentials.js
@@ -33,6 +33,21 @@ if (usedKeys.SUPABASE_SERVICE_KEY && usedKeys.SUPABASE_SERVICE_KEY !== 'SUPABASE
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
 
+// supabase-js returns query failures as { error }, it does not throw them -
+// silently ignoring that field (as the cleanup steps below used to) means a
+// blocked delete (e.g. an FK constraint from a leftover row) logs a false
+// "cleared" and the script proceeds to insert duplicate orgs/users on top of
+// the undeleted ones. "does not exist" is the one error worth tolerating,
+// since it just means the table isn't there yet on a fresh/partial DB.
+function assertCleared(table, error) {
+  if (!error) return
+  if (error.message && error.message.includes('does not exist')) {
+    console.log(`  ⚠️  ${table} does not exist yet, skipping`)
+    return
+  }
+  throw new Error(`Failed to clear ${table}: ${error.message}`)
+}
+
 async function seedDatabase() {
   // Test connection and check schema
   console.log('🔌 Testing connection...')
@@ -80,65 +95,50 @@ async function seedDatabase() {
       // into tests as stale rows visible to super-admin sessions
       'notifications',
       'activity_logs',
+      'data_access_audit',
       'audits',
       'auditor_assignments',
+      // auditor_branch_assignments and zone_assignments hold org_id/created_by
+      // FKs with delete_rule NO ACTION - left uncleared, either blocks the
+      // organizations delete below outright, or (before this fix) let that
+      // failure pass silently and duplicate orgs got inserted on top of it.
+      'auditor_branch_assignments',
+      'zone_assignments',
       'surveys',
       'zone_branches'
     ]
-    
+
     for (const table of clearOrder) {
-      try {
-        const { error } = await supabase.from(table).delete().gte('created_at', '1900-01-01')
-        if (error) {
-          console.log(`  ⚠️  ${table}: ${error.message}`)
-        } else {
-          console.log(`  ✅ Cleared ${table}`)
-        }
-      } catch (err) {
-        console.log(`  ⚠️  ${table}: ${err.message}`)
-      }
+      const { error } = await supabase.from(table).delete().gte('created_at', '1900-01-01')
+      assertCleared(table, error)
+      console.log(`  ✅ Cleared ${table}`)
     }
-    
+
     // Clear FK-constrained tables in correct order
-    try {
-      // 1. Remove branch managers (set to NULL)
-      await supabase.from('branches').update({ manager_id: null }).neq('id', '00000000-0000-0000-0000-000000000000')
-      console.log('  ✅ Nullified branch managers')
-    } catch (err) {
-      console.log(`  ⚠️  branches.manager_id: ${err.message}`)
-    }
-    
-    try {
-      // 2. Delete users
-      await supabase.from('users').delete().gte('created_at', '1900-01-01')
-      console.log('  ✅ Cleared users')
-    } catch (err) {
-      console.log(`  ⚠️  users: ${err.message}`)
-    }
-    
-    try {
-      // 3. Delete branches
-      await supabase.from('branches').delete().gte('created_at', '1900-01-01')
-      console.log('  ✅ Cleared branches')
-    } catch (err) {
-      console.log(`  ⚠️  branches: ${err.message}`)
-    }
-    
-    try {
-      // 4. Delete zones
-      await supabase.from('zones').delete().gte('created_at', '1900-01-01')
-      console.log('  ✅ Cleared zones')
-    } catch (err) {
-      console.log(`  ⚠️  zones: ${err.message}`)
-    }
-    
-    try {
-      // 5. Delete organizations
-      await supabase.from('organizations').delete().gte('created_at', '1900-01-01')
-      console.log('  ✅ Cleared organizations')
-    } catch (err) {
-      console.log(`  ⚠️  organizations: ${err.message}`)
-    }
+    // 1. Remove branch managers (set to NULL)
+    const { error: managerNullError } = await supabase.from('branches').update({ manager_id: null }).neq('id', '00000000-0000-0000-0000-000000000000')
+    assertCleared('branches.manager_id', managerNullError)
+    console.log('  ✅ Nullified branch managers')
+
+    // 2. Delete users
+    const { error: usersError } = await supabase.from('users').delete().gte('created_at', '1900-01-01')
+    assertCleared('users', usersError)
+    console.log('  ✅ Cleared users')
+
+    // 3. Delete branches
+    const { error: branchesError } = await supabase.from('branches').delete().gte('created_at', '1900-01-01')
+    assertCleared('branches', branchesError)
+    console.log('  ✅ Cleared branches')
+
+    // 4. Delete zones
+    const { error: zonesError } = await supabase.from('zones').delete().gte('created_at', '1900-01-01')
+    assertCleared('zones', zonesError)
+    console.log('  ✅ Cleared zones')
+
+    // 5. Delete organizations
+    const { error: orgsError } = await supabase.from('organizations').delete().gte('created_at', '1900-01-01')
+    assertCleared('organizations', orgsError)
+    console.log('  ✅ Cleared organizations')
 
     // Seed organizations
     console.log('🏢 Seeding organizations...')

--- a/scripts/seed-with-credentials.js
+++ b/scripts/seed-with-credentials.js
@@ -37,13 +37,17 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
 // silently ignoring that field (as the cleanup steps below used to) means a
 // blocked delete (e.g. an FK constraint from a leftover row) logs a false
 // "cleared" and the script proceeds to insert duplicate orgs/users on top of
-// the undeleted ones. "does not exist" is the one error worth tolerating,
-// since it just means the table isn't there yet on a fresh/partial DB.
+// the undeleted ones. A missing table is the one error worth tolerating,
+// since it just means the table isn't there yet on a fresh/partial DB - but
+// Postgres and PostgREST phrase that differently ("relation ... does not
+// exist" vs. PostgREST's own "Could not find the table ... in the schema
+// cache"), so check for both rather than just the one observed first.
+// Returns true if the delete actually happened, false if benignly skipped.
 function assertCleared(table, error) {
-  if (!error) return
-  if (error.message && error.message.includes('does not exist')) {
+  if (!error) return true
+  if (error.message && (error.message.includes('does not exist') || error.message.includes('Could not find the table'))) {
     console.log(`  ⚠️  ${table} does not exist yet, skipping`)
-    return
+    return false
   }
   throw new Error(`Failed to clear ${table}: ${error.message}`)
 }
@@ -80,7 +84,15 @@ async function seedDatabase() {
   try {
     // Clear existing data more thoroughly
     console.log('🧹 Clearing existing data...')
-    
+
+    // A DB trigger rejects removing an auditor's assignment from any branch
+    // that's currently is_active=true ("Deactivate the branch first") - the
+    // steady-state result of a prior successful seed run is exactly that
+    // (active branches with assigned auditors), so clearing auditor_assignments
+    // below would otherwise always fail on the second and every later run.
+    const { error: deactivateError } = await supabase.from('branches').update({ is_active: false }).neq('id', '00000000-0000-0000-0000-000000000000')
+    if (assertCleared('branches.is_active', deactivateError)) console.log('  ✅ Deactivated all branches')
+
     // Clear in order that respects foreign key constraints:
     // 1. Audits and their dependencies
     // 2. Branch managers (set to NULL before deleting users)
@@ -110,35 +122,29 @@ async function seedDatabase() {
 
     for (const table of clearOrder) {
       const { error } = await supabase.from(table).delete().gte('created_at', '1900-01-01')
-      assertCleared(table, error)
-      console.log(`  ✅ Cleared ${table}`)
+      if (assertCleared(table, error)) console.log(`  ✅ Cleared ${table}`)
     }
 
     // Clear FK-constrained tables in correct order
     // 1. Remove branch managers (set to NULL)
     const { error: managerNullError } = await supabase.from('branches').update({ manager_id: null }).neq('id', '00000000-0000-0000-0000-000000000000')
-    assertCleared('branches.manager_id', managerNullError)
-    console.log('  ✅ Nullified branch managers')
+    if (assertCleared('branches.manager_id', managerNullError)) console.log('  ✅ Nullified branch managers')
 
     // 2. Delete users
     const { error: usersError } = await supabase.from('users').delete().gte('created_at', '1900-01-01')
-    assertCleared('users', usersError)
-    console.log('  ✅ Cleared users')
+    if (assertCleared('users', usersError)) console.log('  ✅ Cleared users')
 
     // 3. Delete branches
     const { error: branchesError } = await supabase.from('branches').delete().gte('created_at', '1900-01-01')
-    assertCleared('branches', branchesError)
-    console.log('  ✅ Cleared branches')
+    if (assertCleared('branches', branchesError)) console.log('  ✅ Cleared branches')
 
     // 4. Delete zones
     const { error: zonesError } = await supabase.from('zones').delete().gte('created_at', '1900-01-01')
-    assertCleared('zones', zonesError)
-    console.log('  ✅ Cleared zones')
+    if (assertCleared('zones', zonesError)) console.log('  ✅ Cleared zones')
 
     // 5. Delete organizations
     const { error: orgsError } = await supabase.from('organizations').delete().gte('created_at', '1900-01-01')
-    assertCleared('organizations', orgsError)
-    console.log('  ✅ Cleared organizations')
+    if (assertCleared('organizations', orgsError)) console.log('  ✅ Cleared organizations')
 
     // Seed organizations
     console.log('🏢 Seeding organizations...')


### PR DESCRIPTION
## Summary
- `seed-with-credentials.js`'s cleanup phase never checked the `{ error }` returned by `supabase.from(table).delete()` — a blocked delete (e.g. an FK constraint from a leftover row) silently logged "cleared" and the script inserted fresh orgs/users on top of the undeleted ones. This is the root cause of the duplicate "Global Retail Chain" orgs that broke PR #95's e2e run.
- Traced the live FK graph and found three org-referencing tables never cleared at all: `zone_assignments`, `auditor_branch_assignments`, `data_access_audit`. `auditor_branch_assignments` is written by `audit.approval-flow.spec.ts`'s fixtures on every run with no cleanup, so it would reliably block the next seed run's `organizations` delete.
- Added `assertCleared()` (throws unless the error just means the table doesn't exist yet) and applied it to every cleanup step; added the three missing tables to the clear order.

## Note on verification
This is a `scripts/`-only change, so `e2e.yml`'s path-filter will skip the real e2e run (trivial pass) — the seed step this PR touches won't get exercised by this PR's own CI. Recommend either running `node scripts/seed-with-credentials.js` manually against the live target before merging, or accepting that the next `apps/web/`-touching PR's e2e run will be the first real exercise of this path.

## Test plan
- [x] `node --check scripts/seed-with-credentials.js` — syntax valid
- [x] Manual diff review against the live FK graph (queried via Supabase MCP) to confirm clear-order correctness
- [ ] Live run against the target project (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)