### PR TITLE
fix: JSON-safe persisted notification cache, handle_new_user role cast, QA sandbox tooling

### DIFF
--- a/apps/web/src/notifications/useNotifications.ts
+++ b/apps/web/src/notifications/useNotifications.ts
@@ -261,30 +261,35 @@ export function useNotificationsEngine(options: NotificationsEngineOptions = {})
     () => ['notifications', 'derivedRead', user?.id || 'anonymous'] as const,
     [user?.id],
   )
-  const derivedReadQuery = useQuery<Set<string>>({
+  // Query data must stay JSON-serializable: main.tsx persists the whole
+  // QueryClient cache to localStorage via PersistQueryClientProvider, and
+  // JSON.stringify(new Set(...)) produces "{}" (Sets have no enumerable own
+  // properties). With staleTime: Infinity this query never refetches to
+  // self-heal, so once a Set got persisted-then-rehydrated as "{}", every
+  // .has() call on it threw for the rest of the session. Store the plain
+  // array here and derive the Set locally, outside the persisted cache.
+  const derivedReadQuery = useQuery<string[]>({
     queryKey: derivedReadKey,
     queryFn: () => {
       const storageKey = `derivedReadNotifications:${user?.id || 'anonymous'}`
       try {
-        return new Set<string>(JSON.parse(localStorage.getItem(storageKey) || '[]'))
+        return JSON.parse(localStorage.getItem(storageKey) || '[]')
       } catch {
-        return new Set<string>()
+        return []
       }
     },
     staleTime: Infinity,
     enabled: true,
   })
-  const derivedReadIds = derivedReadQuery.data || new Set<string>()
+  const derivedReadIds = React.useMemo(() => new Set<string>(derivedReadQuery.data || []), [derivedReadQuery.data])
 
   const markDerivedAsReadLocal = React.useCallback(
     (id: string) => {
       const storageKey = `derivedReadNotifications:${user?.id || 'anonymous'}`
-      queryClient.setQueryData<Set<string>>(derivedReadKey, (prev) => {
-        const base = prev || new Set<string>()
-        const next = new Set(base)
-        next.add(id)
+      queryClient.setQueryData<string[]>(derivedReadKey, (prev) => {
+        const next = Array.from(new Set([...(prev || []), id]))
         try {
-          localStorage.setItem(storageKey, JSON.stringify(Array.from(next)))
+          localStorage.setItem(storageKey, JSON.stringify(next))
         } catch {
           // ignore storage errors
         }
@@ -406,17 +411,17 @@ export function useNotificationsEngine(options: NotificationsEngineOptions = {})
       const prevAdminInf = queryClient.getQueryData<InfiniteData<Notification[]>>(adminInfKey)
       try {
         const storageKey = `derivedReadNotifications:${user?.id || 'anonymous'}`
-        queryClient.setQueryData<Set<string>>(derivedReadKey, (prevSet) => {
-          const base = prevSet || new Set<string>()
-          const next = new Set(base)
+        queryClient.setQueryData<string[]>(derivedReadKey, (prev) => {
+          const next = new Set(prev || [])
           const curr = Array.isArray(uiNotifications) ? uiNotifications : []
           curr.forEach(n => { if (!isUUID(n.id)) next.add(n.id) })
+          const nextArr = Array.from(next)
           try {
-            localStorage.setItem(storageKey, JSON.stringify(Array.from(next)))
+            localStorage.setItem(storageKey, JSON.stringify(nextArr))
           } catch {
             // ignore storage errors
           }
-          return next
+          return nextArr
         })
       } catch {}
       queryClient.setQueryData<Notification[]>(unreadKey, () => [])

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,6 +2,11 @@
 
 Running log of engineering decisions (newest first). One entry per decision: date, what, why.
 
+## 2026-07-09 — QA sandbox findings
+- **Persisted query cache must stay JSON-safe**: `main.tsx` persists the entire React Query cache to `localStorage` via `JSON.stringify` (`PersistQueryClientProvider`). Non-serializable query data (`Set`, `Map`, `Date`, class instances) silently corrupts on the round-trip (`Set` → `{}`), and with `staleTime: Infinity` never self-heals. Store plain arrays/objects in queries; derive `Set`/`Map` with `useMemo` outside the cache. Found via a `derivedReadIds.has is not a function` error-boundary crash in `useNotifications.ts`.
+- **Enum casts in SQL functions are explicit**: Postgres implicitly casts a bare `'LITERAL'` to an enum column but *not* a `COALESCE(...)` expression result — `handle_new_user()` had failed on every fresh `auth.users` insert (the app's first-login auto-provision path) until `::user_role` was added (migration `20260709124151`).
+- **QA sandbox org added** ("Trakr QA Sandbox", `scripts/seed-qa-org.mjs` + `scripts/qa-smoke.mjs`): persistent per-role accounts and all-six-status audit data for browser QA. Both bugs above were invisible to `tsc`, unit tests, and the e2e suite — surfaced only by exercising real screens with varied data.
+
 ## 2026-07-03 — Production cleanup baseline
 - **Trunk-based flow adopted**: protected `main`, short-lived branches, squash merges, CI (`ci.yml`) + E2E (`e2e.yml`) gates. Scratch files never land at root.
 - **E2E serialized** via `e2e-shared-db` concurrency group — the suite seeds/mutates one shared database; concurrent runs corrupt each other (proven 2026-07-03). Follow-up: dedicated test project.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "clean": "npm run clean --workspaces && rimraf node_modules",
     "install:all": "npm install",
     "seed:db": "node -r dotenv/config scripts/seed-with-credentials.js",
+    "seed:qa": "node -r dotenv/config scripts/seed-qa-org.mjs",
+    "qa:smoke": "node scripts/qa-smoke.mjs",
     "set-passwords": "node -r dotenv/config scripts/set-user-passwords.js",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,15 @@
 
 This directory contains scripts to populate your Supabase database with realistic test data for comprehensive system testing.
 
+## QA Sandbox (manual/visual browser testing)
+
+A persistent, self-contained QA org separate from the e2e seed data. Purely additive — never touches other orgs — and idempotent (re-running confirms "already seeded" and exits).
+
+- `seed-qa-org.mjs` (`npm run seed:qa`) creates org **"Trakr QA Sandbox"**: one user per role (`qa.admin@trakr-test.dev` / `qa.manager@trakr-test.dev` / `qa.auditor@trakr-test.dev`, password `QaTest@12345`), 1 zone, 2 branches, 1 weighted survey, and 10 audits spanning all six statuses. Requires `SUPABASE_URL` (or `VITE_SUPABASE_URL`) and `SUPABASE_SERVICE_KEY` (service role — the script uses auth admin APIs).
+- `qa-smoke.mjs` (`npm run qa:smoke`, dev server must be running; `QA_BASE_URL` overrides `http://localhost:3002`) logs in as each QA account and screenshots their main screens to `test-results/qa-smoke/`. **Inspect the screenshots** — React error-boundary crashes never show up in the reported console/page errors.
+
+Reuse this org for browser QA instead of creating throwaway test data.
+
 ## 🎯 What Gets Seeded
 
 ### Organizations & Structure

--- a/scripts/qa-smoke.mjs
+++ b/scripts/qa-smoke.mjs
@@ -1,0 +1,65 @@
+// Visual smoke test against the "Trakr QA Sandbox" org (see seed-qa-org.mjs).
+// Logs in as each of the three QA accounts, screenshots their main screens to
+// test-results/qa-smoke/, and reports uncaught page/console errors.
+//
+// NOTE: React error-boundary crashes are INVISIBLE to pageerror/console
+// monitoring (the error is caught, the page shows "Page failed to load").
+// Always inspect the screenshots — an empty error list alone proves nothing.
+//
+// Usage: npm run qa:smoke   (dev server must be running; QA_BASE_URL overrides)
+import { chromium } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+const BASE_URL = process.env.QA_BASE_URL || 'http://localhost:3002'
+const SHOT_DIR = 'test-results/qa-smoke'
+const PASSWORD = 'QaTest@12345'
+
+mkdirSync(SHOT_DIR, { recursive: true })
+
+async function loginEmail(page, email) {
+  await page.goto(`${BASE_URL}/login`, { waitUntil: 'networkidle' })
+  await page.fill('input[type="email"]', email)
+  await page.fill('input[type="password"]', PASSWORD)
+  await page.getByRole('button', { name: /Sign in|Log in/i }).click()
+  await page.waitForURL(url => url.pathname.includes('/dashboard'), { timeout: 30_000 })
+}
+
+const CASES = [
+  { email: 'qa.admin@trakr-test.dev', path: '/analytics', shot: 'admin-analytics' },
+  { email: 'qa.manager@trakr-test.dev', path: '/analytics', shot: 'branchmanager-analytics' },
+  { email: 'qa.auditor@trakr-test.dev', path: null, shot: 'auditor-dashboard' },
+]
+
+async function run() {
+  const browser = await chromium.launch()
+  const results = []
+
+  for (const c of CASES) {
+    const page = await browser.newPage()
+    const errors = []
+    page.on('pageerror', (err) => errors.push(String(err)))
+    page.on('console', (msg) => { if (msg.type() === 'error') errors.push(msg.text()) })
+
+    await loginEmail(page, c.email)
+    await page.waitForTimeout(1000)
+    if (c.path) {
+      await page.goto(`${BASE_URL}${c.path}`, { waitUntil: 'networkidle' })
+      await page.waitForTimeout(1000)
+      // Reload once: a fresh Vite dev server can drop the very first Supabase
+      // fetch while modules compile on demand; the second load is stable.
+      await page.reload({ waitUntil: 'networkidle' })
+    }
+    // Drop login/cold-start noise, then give the settled page a window in
+    // which any steady-state errors can surface before we snapshot.
+    errors.length = 0
+    await page.waitForTimeout(1500)
+    await page.screenshot({ path: `${SHOT_DIR}/${c.shot}.png`, fullPage: true })
+    results.push({ account: c.email, screenshot: `${SHOT_DIR}/${c.shot}.png`, errors: [...errors] })
+    await page.close()
+  }
+
+  await browser.close()
+  console.log(JSON.stringify(results, null, 2))
+}
+
+run().catch((err) => { console.error('FAILED:', err); process.exit(1) })

--- a/scripts/seed-qa-org.mjs
+++ b/scripts/seed-qa-org.mjs
@@ -1,0 +1,181 @@
+// Creates a dedicated, self-contained test org with its own admin, branch
+// manager, and auditor, plus zones/branches/survey/audits across every
+// status - for manual visual QA in a browser. Purely additive: never
+// touches any other org's data. Safe to re-run (idempotent by org name).
+import { createClient } from '@supabase/supabase-js'
+
+const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
+const key = process.env.SUPABASE_SERVICE_KEY // service role required: uses auth.admin APIs, no anon fallback
+if (!url || !key) throw new Error('Missing SUPABASE_URL (or VITE_SUPABASE_URL) / SUPABASE_SERVICE_KEY')
+const supa = createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } })
+
+const ORG_NAME = 'Trakr QA Sandbox'
+const PASSWORD = 'QaTest@12345'
+const USERS = [
+  { email: 'qa.admin@trakr-test.dev', role: 'ADMIN', fullName: 'QA Admin' },
+  { email: 'qa.manager@trakr-test.dev', role: 'BRANCH_MANAGER', fullName: 'QA Branch Manager' },
+  { email: 'qa.auditor@trakr-test.dev', role: 'AUDITOR', fullName: 'QA Auditor' },
+]
+
+async function ensureAuthUser(email, password) {
+  const { data: list } = await supa.auth.admin.listUsers({ perPage: 1000 })
+  const existing = list.users.find(u => u.email?.toLowerCase() === email.toLowerCase())
+  if (existing) return existing.id
+  const { data, error } = await supa.auth.admin.createUser({ email, password, email_confirm: true })
+  if (error) throw error
+  return data.user.id
+}
+
+async function main() {
+  console.log(`Creating org "${ORG_NAME}"...`)
+  let { data: org } = await supa.from('organizations').select('id').eq('name', ORG_NAME).maybeSingle()
+  if (!org) {
+    const now = new Date().toISOString()
+    const { data, error } = await supa.from('organizations').insert({ name: ORG_NAME, created_at: now, updated_at: now }).select('id').single()
+    if (error) throw error
+    org = data
+  }
+  const orgId = org.id
+  console.log(`  org_id = ${orgId}`)
+
+  console.log('Creating auth users + public.users rows...')
+  const userIds = {}
+  for (const u of USERS) {
+    const authId = await ensureAuthUser(u.email, PASSWORD)
+    const { data: existing } = await supa.from('users').select('id').eq('email', u.email).maybeSingle()
+    if (existing) {
+      await supa.from('users').update({ org_id: orgId, role: u.role, auth_user_id: authId, full_name: u.fullName, is_active: true }).eq('id', existing.id)
+      userIds[u.role] = existing.id
+    } else {
+      const { data, error } = await supa.from('users').insert({
+        org_id: orgId, email: u.email, role: u.role, auth_user_id: authId, full_name: u.fullName, is_active: true, email_verified: true,
+      }).select('id').single()
+      if (error) throw error
+      userIds[u.role] = data.id
+    }
+  }
+  console.log('  users:', userIds)
+
+  console.log('Creating zone + branches (inactive until auditor coverage assigned)...')
+  const now = new Date().toISOString()
+  let { data: zone } = await supa.from('zones').select('id').eq('org_id', orgId).eq('name', 'QA Zone').maybeSingle()
+  if (!zone) {
+    const { data, error } = await supa.from('zones').insert({ org_id: orgId, name: 'QA Zone', description: 'QA sandbox zone', created_at: now, updated_at: now }).select('id').single()
+    if (error) throw error
+    zone = data
+  }
+  let { data: branches } = await supa.from('branches').select('id, name').eq('org_id', orgId)
+  if (!branches?.length) {
+    const { data, error } = await supa.from('branches').insert([
+      { org_id: orgId, name: 'QA Branch North', address: '1 Test St', is_active: false, manager_id: userIds.BRANCH_MANAGER, created_at: now, updated_at: now },
+      { org_id: orgId, name: 'QA Branch South', address: '2 Test Ave', is_active: false, manager_id: userIds.BRANCH_MANAGER, created_at: now, updated_at: now },
+    ]).select('id, name')
+    if (error) throw error
+    branches = data
+    const { error: zbErr } = await supa.from('zone_branches').insert(branches.map(b => ({ zone_id: zone.id, branch_id: b.id })))
+    if (zbErr) throw zbErr
+  }
+  console.log('  branches:', branches.map(b => b.name))
+
+  console.log('Assigning branch manager + auditor, then activating branches...')
+  const { error: bmaErr } = await supa.from('branch_manager_assignments').upsert(
+    branches.map(b => ({ branch_id: b.id, manager_id: userIds.BRANCH_MANAGER })), { onConflict: 'branch_id,manager_id' }
+  )
+  if (bmaErr) throw bmaErr
+  const { error: aaErr } = await supa.from('auditor_assignments').upsert({
+    user_id: userIds.AUDITOR, org_id: orgId, branch_ids: branches.map(b => b.id), zone_ids: [zone.id], updated_at: now,
+  }, { onConflict: 'user_id' })
+  if (aaErr) throw aaErr
+  // Auditor coverage must exist BEFORE a branch can be activated (DB trigger guard).
+  const { error: activateErr } = await supa.from('branches').update({ is_active: true }).in('id', branches.map(b => b.id))
+  if (activateErr) throw activateErr
+
+  console.log('Creating survey with weighted questions...')
+  let { data: survey } = await supa.from('surveys').select('id, version').eq('org_id', orgId).eq('title', 'QA Store Compliance Audit').maybeSingle()
+  let section
+  if (!survey) {
+    const { data, error } = await supa.from('surveys').insert({
+      org_id: orgId, title: 'QA Store Compliance Audit', description: 'QA sandbox survey', is_active: true, version: 1, frequency: 'UNLIMITED', created_at: now, updated_at: now,
+    }).select('id, version').single()
+    if (error) throw error
+    survey = data
+    const { data: sec, error: secErr } = await supa.from('survey_sections').insert({ survey_id: survey.id, title: 'Compliance Checklist', description: 'Auto', order_num: 0 }).select('id').single()
+    if (secErr) throw secErr
+    section = sec
+  } else {
+    const { data: sec, error: secErr } = await supa.from('survey_sections').select('id').eq('survey_id', survey.id).limit(1).single()
+    if (secErr) throw secErr
+    section = sec
+  }
+  let { data: questions } = await supa.from('survey_questions').select('id, yes_weight, no_weight').eq('survey_id', survey.id).order('order_num')
+  if (!questions?.length) {
+    const questionDefs = [
+      { text: 'Fire exits clear and unlocked?', yes: 20, no: 0 },
+      { text: 'First aid kit stocked and accessible?', yes: 15, no: 0 },
+      { text: 'Cleanliness standards met?', yes: 20, no: 0 },
+      { text: 'Staff wearing proper uniform?', yes: 15, no: 0 },
+      { text: 'Cash handling procedures followed?', yes: 30, no: 0 },
+    ]
+    const { data, error: qErr } = await supa.from('survey_questions').insert(
+      questionDefs.map((q, i) => ({
+        survey_id: survey.id, section_id: section.id, question_text: q.text, question_type: 'yes_no',
+        required: true, order_num: i, is_weighted: true, yes_weight: q.yes, no_weight: q.no,
+      }))
+    ).select('id, yes_weight, no_weight')
+    if (qErr) throw qErr
+    questions = data
+  }
+
+  const { count: existingAuditCount } = await supa.from('audits').select('id', { count: 'exact', head: true }).eq('org_id', orgId)
+  if (existingAuditCount > 0) {
+    console.log(`  ${existingAuditCount} audits already exist for this org, skipping audit creation.`)
+    console.log('\n=== QA Sandbox Ready (already seeded) ===')
+    console.log(`Org: ${ORG_NAME} (${orgId})`)
+    console.log(`Password for all 3 accounts: ${PASSWORD}`)
+    for (const u of USERS) console.log(`  ${u.role.padEnd(15)} ${u.email}`)
+    return
+  }
+
+  console.log('Creating audits across every status...')
+  const endOfDay = (d) => { const e = new Date(d); e.setHours(23, 59, 59, 999); return e }
+  const daysAgo = (n) => { const d = new Date(); d.setDate(d.getDate() - n); return d }
+
+  const allYes = Object.fromEntries(questions.map(q => [q.id, 'yes']))
+  const mostlyYes = Object.fromEntries(questions.map((q, i) => [q.id, i === 0 ? 'no' : 'yes']))
+  const mixed = Object.fromEntries(questions.map((q, i) => [q.id, i % 2 === 0 ? 'yes' : 'no']))
+
+  function baseAudit(branchId, status, responses, createdDaysAgo) {
+    const created = daysAgo(createdDaysAgo)
+    return {
+      org_id: orgId, branch_id: branchId, survey_id: survey.id, survey_version: survey.version,
+      assigned_to: userIds.AUDITOR, status, responses, na_reasons: {}, section_comments: {},
+      created_at: created.toISOString(), updated_at: created.toISOString(),
+      period_start: created.toISOString(), period_end: endOfDay(created).toISOString(), due_at: endOfDay(created).toISOString(),
+      is_archived: false,
+    }
+  }
+
+  const audits = [
+    { ...baseAudit(branches[0].id, 'APPROVED', allYes, 10), submitted_by: userIds.AUDITOR, submitted_at: daysAgo(9).toISOString(), approved_by: userIds.ADMIN, approved_at: daysAgo(8).toISOString(), approval_note: 'Excellent compliance.' },
+    { ...baseAudit(branches[1].id, 'APPROVED', mostlyYes, 7), submitted_by: userIds.AUDITOR, submitted_at: daysAgo(6).toISOString(), approved_by: userIds.ADMIN, approved_at: daysAgo(5).toISOString(), approval_note: 'Good, minor note on fire exit.' },
+    { ...baseAudit(branches[0].id, 'APPROVED', mixed, 20), submitted_by: userIds.AUDITOR, submitted_at: daysAgo(19).toISOString(), approved_by: userIds.ADMIN, approved_at: daysAgo(18).toISOString(), approval_note: 'Approved after review.' },
+    { ...baseAudit(branches[1].id, 'REJECTED', mixed, 4), submitted_by: userIds.AUDITOR, submitted_at: daysAgo(3).toISOString(), rejected_by: userIds.ADMIN, rejected_at: daysAgo(2).toISOString(), rejection_note: 'Please recheck cash handling procedures.' },
+    { ...baseAudit(branches[0].id, 'REJECTED', mostlyYes, 15), submitted_by: userIds.AUDITOR, submitted_at: daysAgo(14).toISOString(), rejected_by: userIds.ADMIN, rejected_at: daysAgo(13).toISOString(), rejection_note: 'Fire exit photo unclear, resubmit.' },
+    { ...baseAudit(branches[1].id, 'SUBMITTED', allYes, 2), submitted_by: userIds.AUDITOR, submitted_at: daysAgo(1).toISOString() },
+    { ...baseAudit(branches[0].id, 'SUBMITTED', mixed, 1), submitted_by: userIds.AUDITOR, submitted_at: new Date().toISOString() },
+    { ...baseAudit(branches[1].id, 'COMPLETED', allYes, 0) },
+    { ...baseAudit(branches[0].id, 'IN_PROGRESS', { [questions[0].id]: 'yes' }, 0) },
+    { ...baseAudit(branches[1].id, 'DRAFT', {}, 12) },
+  ]
+
+  const { data: created, error: aErr } = await supa.from('audits').insert(audits).select('id, status')
+  if (aErr) throw aErr
+  console.log(`  created ${created.length} audits:`, created.reduce((acc, a) => { acc[a.status] = (acc[a.status] || 0) + 1; return acc }, {}))
+
+  console.log('\n=== QA Sandbox Ready ===')
+  console.log(`Org: ${ORG_NAME} (${orgId})`)
+  console.log(`Password for all 3 accounts: ${PASSWORD}`)
+  for (const u of USERS) console.log(`  ${u.role.padEnd(15)} ${u.email}`)
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/supabase/migrations/20260709124151_fix_handle_new_user_role_cast.sql
+++ b/supabase/migrations/20260709124151_fix_handle_new_user_role_cast.sql
@@ -1,0 +1,44 @@
+-- handle_new_user()'s COALESCE(NEW.raw_user_meta_data->>'role', 'AUDITOR')
+-- returns text, but public.users.role is the user_role enum. Postgres does
+-- not implicitly cast a COALESCE expression result to an enum (only bare
+-- literals get that treatment), so this INSERT has always failed with
+-- "column role is of type user_role but expression is of type text" on any
+-- fresh auth.users row - including the real "auto-provision" signUp()
+-- fallback in stores/auth.ts and LoginScreen.tsx for first-time logins by
+-- seeded users. Add the missing cast.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  INSERT INTO public.users (
+    id,
+    auth_user_id,
+    email,
+    full_name,
+    role,
+    org_id,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    NEW.id,
+    NEW.id,
+    NEW.email,
+    COALESCE(
+      NEW.raw_user_meta_data->>'full_name',
+      NEW.raw_user_meta_data->>'name',
+      split_part(NEW.email, '@', 1)
+    ),
+    COALESCE(NEW.raw_user_meta_data->>'role', 'AUDITOR')::user_role,
+    (NEW.raw_user_meta_data->>'org_id')::UUID,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$function$


### PR DESCRIPTION
## Summary
- **fix(notifications)**: `useNotifications.ts` stored a `Set` as React Query data, but `main.tsx` persists the whole query cache to localStorage via `PersistQueryClientProvider` — `JSON.stringify(new Set) === '{}'`, and with `staleTime: Infinity` the corruption never self-heals. `derivedReadIds.has()` then threw and the error boundary blanked the page (invisible to console monitoring). Now stores `string[]` (all three writers) and derives the `Set` via `useMemo` outside the persisted cache.
- **fix(db)**: commits migration `20260709124151` (already applied live with the same stamp) — `handle_new_user()` needed an explicit `::user_role` cast; Postgres doesn't implicitly cast a `COALESCE(...)` result to an enum, so every fresh `auth.users` insert failed, including the app's first-login auto-provision fallback.
- **chore(qa)**: reusable QA sandbox tooling — `npm run seed:qa` idempotently creates the "Trakr QA Sandbox" org (per-role accounts, zone/branches/weighted survey, 10 audits across all six statuses); `npm run qa:smoke` screenshots each role's main screens. Both bugs above were found this way and were invisible to tsc/vitest/e2e.

## Verification
- `npm run type-check` clean; `npm run build:web` succeeds.
- Vitest: 31 passed / 0 failed; 5 suite-level fixture failures are pre-existing on `main` (local Node 24 + jsdom AbortSignal realm mismatch — verified identical on a clean `main` checkout; CI runs Node 20 where they pass).
- Both scripts re-run from their committed locations (seeder hits its idempotent path; smoke test screenshots all 3 roles).
- Visual verification: all three role screens render with real data, notifications crash gone (verified via screenshots after a fresh dev-server restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)