### PR TITLE
fix(storage): restore SELECT policy required by the upload path

### DIFF
--- a/supabase/migrations/20260709194139_fix_storage_select_policy_for_uploads.sql
+++ b/supabase/migrations/20260709194139_fix_storage_select_policy_for_uploads.sql
@@ -1,0 +1,12 @@
+-- 20260703150433_storage_prod_policies dropped every SELECT policy on
+-- storage.objects, reasoning that reads go through public bucket URLs and
+-- omitting SELECT closes the listing/enumeration advisor warning. But the
+-- storage API's upload path itself needs SELECT on the object row it inserts
+-- (insert-returning / upsert existence check), so every authenticated upload
+-- (avatars, signatures, audit photos) has failed with an RLS violation since
+-- then. Restore SELECT for authenticated users only, scoped to the two app
+-- media buckets - anon listing/enumeration stays blocked, preserving the
+-- original hardening goal.
+CREATE POLICY app_media_select ON storage.objects
+  FOR SELECT TO authenticated
+  USING (bucket_id IN ('audit-photos', 'profile-media'));


### PR DESCRIPTION
## Summary
The 2026-07-03 storage hardening (`20260703150433_storage_prod_policies`) dropped every SELECT policy on `storage.objects`, reasoning reads go through public bucket URLs and omitting SELECT closes the listing/enumeration advisor warning. But the storage API's **upload path needs SELECT on the object row it inserts** (insert-returning / upsert existence check) — so **every authenticated upload (avatars, signatures, audit photos) has failed with an RLS violation in production since July 3**.

Why nothing caught it: e2e has zero upload coverage, and the vitest storage integration suites that do cover it were invisibly broken — skipped in CI (no Supabase env on the unit-test step) and failing at the transport level locally on Node 24 (jsdom/undici realm bug, fix in the next PR).

## Fix
One new policy, applied live (stamp `20260709194139`) with user authorization and committed here for repo/DB parity:
- `app_media_select` — SELECT **to authenticated only**, scoped to `audit-photos` + `profile-media`. Anon listing/enumeration stays blocked, preserving the original hardening goal.

## Verification
- Plain-Node reproduction before fix: authenticated upload → `new row violates row-level security policy`. After fix: upload OK.
- Anon `.list()` still returns zero rows (RLS-filtered).
- Full vitest storage integration suite green (with the realm fix from the follow-up PR applied locally); full unit suite 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)