### PR TITLE
test(vitest): keep the fetch stack in one realm under jsdom

### DIFF
--- a/apps/web/src/setupTests.ts
+++ b/apps/web/src/setupTests.ts
@@ -1,3 +1,4 @@
+import './tests/realmFix' // MUST stay first: swaps jsdom globals for Node natives before app modules load
 import '@testing-library/jest-dom'
 import { beforeAll } from 'vitest'
 import { getSupabase } from './utils/supabaseClient'

--- a/apps/web/src/tests/realmFix.ts
+++ b/apps/web/src/tests/realmFix.ts
@@ -1,0 +1,31 @@
+// Realm fix for vitest's jsdom environment. jsdom ships no fetch, so Node's
+// native undici fetch stays global — but jsdom shadows AbortController,
+// AbortSignal, Blob, File, and FormData with its own realm's classes, and
+// undici only honors its own realm:
+// - Undici v7 (Node >=24) brand-checks RequestInit.signal, so circuitBreaker's
+//   `new AbortController()` passed into fetch throws.
+// - storage-js wraps Blob bodies in `new FormData()`; a jsdom FormData isn't
+//   recognized by undici as multipart and gets string-coerced, so uploads
+//   arrive as text/plain and the buckets' MIME allow-list rejects them.
+// Restore Node natives so the whole fetch stack lives in one realm. This
+// module must be the FIRST import of setupTests so the swaps happen before
+// any app/supabase module evaluates. Safe while no DOM addEventListener uses
+// { signal } (currently zero call sites); if one appears, bridge signals
+// inside a fetch wrapper here instead.
+import { transferableAbortController } from 'node:util'
+import { Blob as NodeBlob, File as NodeFile } from 'node:buffer'
+
+const nativeController = transferableAbortController()
+globalThis.AbortController = nativeController.constructor as typeof AbortController
+globalThis.AbortSignal = (nativeController.signal.constructor as unknown) as typeof AbortSignal
+globalThis.Blob = NodeBlob as unknown as typeof Blob
+globalThis.File = NodeFile as unknown as typeof File
+
+// jsdom has no Response either, so this is Node's — its .formData() yields a
+// native undici FormData, the only way back to that class once shadowed.
+const nativeFormData = await new Response('a=b', {
+  headers: { 'content-type': 'application/x-www-form-urlencoded' },
+}).formData()
+globalThis.FormData = nativeFormData.constructor as typeof FormData
+
+export {}


### PR DESCRIPTION
## Summary
vitest's jsdom environment keeps Node's native undici `fetch` (jsdom ships none) but shadows `AbortController`/`AbortSignal`/`Blob`/`File`/`FormData` with jsdom-realm classes, which undici doesn't honor:
- Undici v7 (Node ≥24) brand-checks `RequestInit.signal` → `circuitBreaker`'s `new AbortController()` + fetch threw, killing **all five Supabase fixture suites at setup** on Node 24 dev machines.
- storage-js wraps Blob bodies in `new FormData()` → jsdom FormData isn't recognized by undici as multipart, uploads arrive string-coerced as `text/plain`, and the buckets' MIME allow-list rejects them.

New `src/tests/realmFix.ts` restores the Node natives (FormData recovered via `Response.formData()` — the only route back once shadowed) and must remain the **first import** of `setupTests.ts` so swaps precede app-module evaluation.

## Impact
The storage/integration suites run again for the first time in months — which is exactly what surfaced the production storage-RLS upload bug fixed in #99. These suites skip in CI (no Supabase env on the unit-test step), so this fix's beneficiaries are local dev runs — and they're a prerequisite for the Node 22 CI bump next.

## Verification
- Node 24 local, full suite: **42/42 passed, 9/9 suites** (previously 5 suites hard-failed at setup).
- `tsc --noEmit` clean; occasional single-test wobble across repeated full runs is pre-existing live-shared-DB interference between integration suites, unrelated to this change.

Part of the approved dependency-refresh plan (A2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)