### PR TITLE
chore(deps): date-fns 3 → 4

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "ag-grid-community": "^34.3.1",
     "ag-grid-react": "^34.2.0",
     "clsx": "^2.0.0",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.4.0",
     "exceljs": "^4.4.0",
     "jspdf": "^3.0.3",
     "jspdf-autotable": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "ag-grid-community": "^34.3.1",
         "ag-grid-react": "^34.2.0",
         "clsx": "^2.0.0",
-        "date-fns": "^3.6.0",
+        "date-fns": "^4.4.0",
         "exceljs": "^4.4.0",
         "jspdf": "^3.0.3",
         "jspdf-autotable": "^5.0.2",
@@ -5008,9 +5008,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11963,7 +11963,7 @@
       "name": "@trakr/shared",
       "version": "1.0.0",
       "dependencies": {
-        "date-fns": "^3.0.0"
+        "date-fns": "^4.4.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "date-fns": "^3.0.0"
+    "date-fns": "^4.4.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",


### PR DESCRIPTION
Phase D2. Four import sites (`format`, `parseISO`, `formatDistanceToNow` in SurveyCharts, AuditHistory, exportUtils, shared/utils/date) — all API-stable across the major; v4's breaking changes (separate `@date-fns/tz`, dropped Flow types) don't touch this codebase.

Verification: type-check clean · vitest 42/42 · build green · e2e exercises date rendering on every dashboard/list screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)