### PR TITLE
chore(deps): remove unused root dependencies (lucide-react, duplicate persist-client)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,6 @@
         "packages/*",
         "apps/*"
       ],
-      "dependencies": {
-        "@tanstack/react-query-persist-client": "^5.90.2",
-        "lucide-react": "^0.553.0"
-      },
       "devDependencies": {
         "@types/node": "^24.5.2",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -8163,15 +8159,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.553.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
-      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -56,9 +56,5 @@
     "monorepo"
   ],
   "author": "Ahmad Karmi",
-  "license": "MIT",
-  "dependencies": {
-    "@tanstack/react-query-persist-client": "^5.90.2",
-    "lucide-react": "^0.553.0"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
Phase D3, with a twist: `lucide-react` was queued for a 0.553→1.x major bump, but the usage grep came back **empty — it's imported nowhere**. Deletion is the correct update. Also removes the root-level duplicate of `@tanstack/react-query-persist-client` (apps/web declares its own, which is what `main.tsx` resolves).

Verification: type-check clean · build green (persist-client resolves from apps/web's declaration) · e2e on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)