### PR TITLE
chore(deps): jspdf 3 → 4

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,7 @@
     "clsx": "^2.0.0",
     "date-fns": "^4.4.0",
     "exceljs": "^4.4.0",
-    "jspdf": "^3.0.3",
+    "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.2",
     "plotly.js": "^3.1.1",
     "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "clsx": "^2.0.0",
         "date-fns": "^4.4.0",
         "exceljs": "^4.4.0",
-        "jspdf": "^3.0.3",
+        "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.2",
         "plotly.js": "^3.1.1",
         "react": "^18.2.0",
@@ -7968,19 +7968,19 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
-      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
+        "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
         "fflate": "^0.8.1"
       },
       "optionalDependencies": {
         "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.3.1",
         "html2canvas": "^1.0.0-rc.5"
       }
     },


### PR DESCRIPTION
Phase D5. Clears the last **critical** advisory cluster (PDF injection / LFI / decoder DoS — GHSA-f8cm-6447-x5h2 et al). `jspdf-autotable` 5.0.8 already peer-supports `^4`. `npm audit`: **0 critical** remaining (8 total: dev-only minimatch + exceljs's uuid, both tracked).

Verification: type-check + build clean · **real PDF exported through the UI** (audit summary → PDF): valid `%PDF-` header, 11.8KB · e2e export specs (CSV/Excel/PDF) run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)