### PR TITLE
chore(deps): react-router-dom 6 → 7

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.6.0",
     "react-plotly.js": "^2.6.0",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.1",
     "recharts": "^3.9.2",
     "tailwind-merge": "^2.0.0",
     "zustand": "^5.0.14"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -178,7 +178,7 @@ function App() {
       <ToastProvider>
         {/** Session error watcher must be inside ToastProvider */}
         <SessionWatcher />
-        <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Router>
           <OrganizationProvider>
             <ErrorBoundary>
           <div className="app-shell">

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.6.0",
         "react-plotly.js": "^2.6.0",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.1",
         "recharts": "^3.9.2",
         "tailwind-merge": "^2.0.0",
         "zustand": "^5.0.14"
@@ -1520,15 +1520,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4739,6 +4730,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js": {
       "version": "3.49.0",
@@ -9769,35 +9773,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-stately": {
@@ -10298,6 +10308,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",


### PR DESCRIPTION
Phase D7. Low-drama in practice: the v7 future flags (`v7_startTransition`, `v7_relativeSplatPath`) were **already enabled** on the Router, so the behavioral migration happened back in the v6 era — v7 makes them defaults and drops the `future` prop (the one required code change). The API surface used (BrowserRouter, Link, MemoryRouter, Navigate, Route(s), useLocation/useNavigate/useParams/useSearchParams — 29 files) is unchanged in v7's declarative mode. Retires the `@remix-run/router` package (and its advisory line) permanently.

## Verification
- type-check + build clean · vitest 42/42 (MemoryRouter-based unit tests included)
- **Browser navigation battery**: login redirect → sidebar Link nav → deep-link `/analytics?tab=reports` (useSearchParams) → hard refresh on nested route → back/forward → unknown-route fallback. Zero page errors.
- Full e2e on this PR (routing is the spine of every spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)