### PR TITLE
chore(seed): preserve QA sandbox org, fix phantom clears, bootstrap auth users

### DIFF
--- a/apps/web/src/utils/supabaseApi.ts
+++ b/apps/web/src/utils/supabaseApi.ts
@@ -2250,7 +2250,10 @@ export const supabaseApi = {
       throw insert.error
     }
     
-    logger.debug('Notification created successfully', { context: 'SupabaseAPI', data: insert.data })
+    logger.debug('Notification created successfully', {
+      context: 'SupabaseAPI',
+      data: { userId: notification.userId, type: notification.type, relatedId: notification.relatedId },
+    })
   },
 
   async completeNotificationAction(relatedId: string, actionType: string): Promise<void> {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,7 @@ A persistent, self-contained QA org separate from the e2e seed data. Purely addi
 - `seed-qa-org.mjs` (`npm run seed:qa`) creates org **"Trakr QA Sandbox"**: one user per role (`qa.admin@trakr-test.dev` / `qa.manager@trakr-test.dev` / `qa.auditor@trakr-test.dev`, password `QaTest@12345`), 1 zone, 2 branches, 1 weighted survey, and 10 audits spanning all six statuses. Requires `SUPABASE_URL` (or `VITE_SUPABASE_URL`) and `SUPABASE_SERVICE_KEY` (service role — the script uses auth admin APIs).
 - `qa-smoke.mjs` (`npm run qa:smoke`, dev server must be running; `QA_BASE_URL` overrides `http://localhost:3002`) logs in as each QA account and screenshots their main screens to `test-results/qa-smoke/`. **Inspect the screenshots** — React error-boundary crashes never show up in the reported console/page errors.
 
-Reuse this org for browser QA instead of creating throwaway test data.
+Reuse this org for browser QA instead of creating throwaway test data. The e2e seeder (`seed-with-credentials.js`) preserves this org by name — CI runs no longer wipe it, so re-running `seed:qa` is only needed if you intentionally change its data.
 
 ## 🎯 What Gets Seeded
 

--- a/scripts/seed-with-credentials.js
+++ b/scripts/seed-with-credentials.js
@@ -45,12 +45,20 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
 // Returns true if the delete actually happened, false if benignly skipped.
 function assertCleared(table, error) {
   if (!error) return true
-  if (error.message && (error.message.includes('does not exist') || error.message.includes('Could not find the table'))) {
+  // Match only MISSING-TABLE wordings. A bare includes('does not exist')
+  // used to also swallow "column X does not exist" - which is how the old
+  // created_at-filtered deletes on zone_branches/audit_photos silently
+  // no-opped on every run while logging ERRORs in Postgres.
+  if (error.message && (/relation .* does not exist/.test(error.message) || error.message.includes('Could not find the table'))) {
     console.log(`  ⚠️  ${table} does not exist yet, skipping`)
     return false
   }
   throw new Error(`Failed to clear ${table}: ${error.message}`)
 }
+
+// Orgs the e2e reseed must never touch: the persistent browser-QA sandbox
+// (see scripts/seed-qa-org.mjs). Everything else is fair game.
+const PRESERVED_ORG_NAMES = ['Trakr QA Sandbox']
 
 async function seedDatabase() {
   // Test connection and check schema
@@ -85,65 +93,79 @@ async function seedDatabase() {
     // Clear existing data more thoroughly
     console.log('🧹 Clearing existing data...')
 
+    // Resolve orgs the reseed must preserve (the persistent QA sandbox).
+    // All clears below exclude these org ids, so browser-QA data survives
+    // every CI e2e run instead of needing seed:qa after each one.
+    const { data: preservedOrgs, error: preservedErr } = await supabase
+      .from('organizations').select('id, name').in('name', PRESERVED_ORG_NAMES)
+    if (preservedErr && !/relation .* does not exist/.test(preservedErr.message || '')) throw preservedErr
+    const preservedOrgIds = (preservedOrgs || []).map(o => o.id)
+    if (preservedOrgIds.length) {
+      console.log(`  🛡️  Preserving org(s): ${(preservedOrgs || []).map(o => o.name).join(', ')}`)
+    }
+
+    // Filter helper: delete/update everything EXCEPT preserved orgs' rows.
+    // NULL org_id rows must still match (PostgREST neq drops NULLs), hence
+    // the or(). With nothing to preserve, match all rows via a tautology
+    // that works on every table regardless of its columns.
+    const exceptPreserved = (query, col = 'org_id') =>
+      preservedOrgIds.length
+        ? query.or(`${col}.is.null,${col}.not.in.(${preservedOrgIds.join(',')})`)
+        : query.or(`${col}.is.null,${col}.not.is.null`)
+
     // A DB trigger rejects removing an auditor's assignment from any branch
     // that's currently is_active=true ("Deactivate the branch first") - the
     // steady-state result of a prior successful seed run is exactly that
     // (active branches with assigned auditors), so clearing auditor_assignments
     // below would otherwise always fail on the second and every later run.
-    const { error: deactivateError } = await supabase.from('branches').update({ is_active: false }).neq('id', '00000000-0000-0000-0000-000000000000')
-    if (assertCleared('branches.is_active', deactivateError)) console.log('  ✅ Deactivated all branches')
+    const { error: deactivateError } = await exceptPreserved(supabase.from('branches').update({ is_active: false }))
+    if (assertCleared('branches.is_active', deactivateError)) console.log('  ✅ Deactivated branches (non-preserved)')
 
-    // Clear in order that respects foreign key constraints:
-    // 1. Audits and their dependencies
-    // 2. Branch managers (set to NULL before deleting users)
-    // 3. Users
-    // 4. Branches and zones
-    // 5. Organizations
+    // Clear in order that respects foreign key constraints. Tables whose
+    // rows die via ON DELETE CASCADE are deliberately absent:
+    //   audit_photos  -> cascades from audits
+    //   zone_branches -> cascades from zones/branches
+    //   notifications -> cascades from users
+    // (audit_comments has no table in the live schema at all.)
+    // activity_logs/data_access_audit/auditor_branch_assignments/
+    // zone_assignments hold NO ACTION FKs on org_id/user_id/created_by and
+    // must be cleared explicitly before users/organizations.
     const clearOrder = [
-      'audit_photos',
-      'audit_comments',
-      // users are recreated with new ids below; notifications and activity
-      // logs would otherwise survive with dangling user references and leak
-      // into tests as stale rows visible to super-admin sessions
-      'notifications',
       'activity_logs',
       'data_access_audit',
       'audits',
       'auditor_assignments',
-      // auditor_branch_assignments and zone_assignments hold org_id/created_by
-      // FKs with delete_rule NO ACTION - left uncleared, either blocks the
-      // organizations delete below outright, or (before this fix) let that
-      // failure pass silently and duplicate orgs got inserted on top of it.
       'auditor_branch_assignments',
       'zone_assignments',
       'surveys',
-      'zone_branches'
     ]
 
     for (const table of clearOrder) {
-      const { error } = await supabase.from(table).delete().gte('created_at', '1900-01-01')
+      const { error } = await exceptPreserved(supabase.from(table).delete())
       if (assertCleared(table, error)) console.log(`  ✅ Cleared ${table}`)
     }
 
     // Clear FK-constrained tables in correct order
     // 1. Remove branch managers (set to NULL)
-    const { error: managerNullError } = await supabase.from('branches').update({ manager_id: null }).neq('id', '00000000-0000-0000-0000-000000000000')
+    const { error: managerNullError } = await exceptPreserved(supabase.from('branches').update({ manager_id: null }))
     if (assertCleared('branches.manager_id', managerNullError)) console.log('  ✅ Nullified branch managers')
 
     // 2. Delete users
-    const { error: usersError } = await supabase.from('users').delete().gte('created_at', '1900-01-01')
+    const { error: usersError } = await exceptPreserved(supabase.from('users').delete())
     if (assertCleared('users', usersError)) console.log('  ✅ Cleared users')
 
     // 3. Delete branches
-    const { error: branchesError } = await supabase.from('branches').delete().gte('created_at', '1900-01-01')
+    const { error: branchesError } = await exceptPreserved(supabase.from('branches').delete())
     if (assertCleared('branches', branchesError)) console.log('  ✅ Cleared branches')
 
     // 4. Delete zones
-    const { error: zonesError } = await supabase.from('zones').delete().gte('created_at', '1900-01-01')
+    const { error: zonesError } = await exceptPreserved(supabase.from('zones').delete())
     if (assertCleared('zones', zonesError)) console.log('  ✅ Cleared zones')
 
     // 5. Delete organizations
-    const { error: orgsError } = await supabase.from('organizations').delete().gte('created_at', '1900-01-01')
+    const { error: orgsError } = preservedOrgIds.length
+      ? await supabase.from('organizations').delete().not('id', 'in', `(${preservedOrgIds.join(',')})`)
+      : await supabase.from('organizations').delete().gte('created_at', '1900-01-01')
     if (assertCleared('organizations', orgsError)) console.log('  ✅ Cleared organizations')
 
     // Seed organizations
@@ -293,6 +315,27 @@ async function seedDatabase() {
     console.log('  • 8 Branches (Manhattan, Brooklyn, Miami, Atlanta, LA, SF, Dallas, Houston)')
     console.log('  • 7 Users (1 admin, 3 branch managers, 3 auditors)')
     
+    // Ensure every seeded user has an auth account. On the long-lived shared
+    // project these already exist; on a fresh project (e.g. a dedicated e2e
+    // database) this bootstraps them so the seed is fully self-contained.
+    // Password matches scripts/set-user-passwords.js's default so the vitest
+    // integration suites' signInWithPassword works out of the box.
+    console.log('\n👤 Ensuring auth accounts exist...')
+    const SEED_USER_PASSWORD = process.env.SEED_USER_PASSWORD || 'Password@123'
+    const { data: preList, error: preListError } = await supabase.auth.admin.listUsers({ perPage: 1000 })
+    if (preListError) throw preListError
+    const existingAuthEmails = new Set((preList.users || []).map(u => (u.email || '').toLowerCase()))
+    for (const seeded of userData || []) {
+      if (existingAuthEmails.has(seeded.email.toLowerCase())) continue
+      const { error: createErr } = await supabase.auth.admin.createUser({
+        email: seeded.email,
+        password: SEED_USER_PASSWORD,
+        email_confirm: true,
+      })
+      if (createErr) throw new Error(`Failed to create auth user ${seeded.email}: ${createErr.message}`)
+      console.log(`  ✅ Created auth account for ${seeded.email}`)
+    }
+
     // Link freshly seeded public.users rows to their auth accounts. The seed
     // recreates rows with new ids; without auth_user_id the org-scoped RLS
     // policies hide every row from the logged-in user and login fails.

--- a/scripts/seed-with-credentials.js
+++ b/scripts/seed-with-credentials.js
@@ -168,6 +168,39 @@ async function seedDatabase() {
       : await supabase.from('organizations').delete().gte('created_at', '1900-01-01')
     if (assertCleared('organizations', orgsError)) console.log('  ✅ Cleared organizations')
 
+    // Ensure every seeded user has an auth account. On the long-lived shared
+    // project most already exist; on a fresh project (e.g. a dedicated e2e
+    // database) this bootstraps them so the seed is fully self-contained.
+    // MUST run BEFORE the public.users upsert below: handle_new_user() fires
+    // on auth-user creation and inserts a public.users row keyed on the auth
+    // id - if a row with the same email already exists under a different id,
+    // the trigger hits the users email unique constraint and GoTrue returns
+    // an opaque 500. Created first, the trigger's rows simply get their
+    // org/role filled in by the email-conflict upsert. Password matches
+    // scripts/set-user-passwords.js's default so the vitest integration
+    // suites' signInWithPassword works out of the box.
+    console.log('👤 Ensuring auth accounts exist...')
+    const SEED_USER_PASSWORD = process.env.SEED_USER_PASSWORD || 'Password@123'
+    const SEED_AUTH_EMAILS = [
+      'admin@trakr.com', 'branchmanager@trakr.com', 'auditor@trakr.com',
+      'admin@retailchain.com', 'manager.manhattan@retailchain.com',
+      'manager.miami@retailchain.com', 'manager.la@retailchain.com',
+      'auditor1@retailchain.com', 'auditor2@retailchain.com', 'auditor3@retailchain.com',
+    ]
+    const { data: preList, error: preListError } = await supabase.auth.admin.listUsers({ perPage: 1000 })
+    if (preListError) throw preListError
+    const existingAuthEmails = new Set((preList.users || []).map(u => (u.email || '').toLowerCase()))
+    for (const email of SEED_AUTH_EMAILS) {
+      if (existingAuthEmails.has(email.toLowerCase())) continue
+      const { error: createErr } = await supabase.auth.admin.createUser({
+        email,
+        password: SEED_USER_PASSWORD,
+        email_confirm: true,
+      })
+      if (createErr) throw new Error(`Failed to create auth user ${email}: ${createErr.name || ''} ${createErr.status || ''} ${createErr.message}`)
+      console.log(`  ✅ Created auth account for ${email}`)
+    }
+
     // Seed organizations
     console.log('🏢 Seeding organizations...')
     const { data: orgData, error: orgError } = await supabase.from('organizations').insert([
@@ -315,27 +348,6 @@ async function seedDatabase() {
     console.log('  • 8 Branches (Manhattan, Brooklyn, Miami, Atlanta, LA, SF, Dallas, Houston)')
     console.log('  • 7 Users (1 admin, 3 branch managers, 3 auditors)')
     
-    // Ensure every seeded user has an auth account. On the long-lived shared
-    // project these already exist; on a fresh project (e.g. a dedicated e2e
-    // database) this bootstraps them so the seed is fully self-contained.
-    // Password matches scripts/set-user-passwords.js's default so the vitest
-    // integration suites' signInWithPassword works out of the box.
-    console.log('\n👤 Ensuring auth accounts exist...')
-    const SEED_USER_PASSWORD = process.env.SEED_USER_PASSWORD || 'Password@123'
-    const { data: preList, error: preListError } = await supabase.auth.admin.listUsers({ perPage: 1000 })
-    if (preListError) throw preListError
-    const existingAuthEmails = new Set((preList.users || []).map(u => (u.email || '').toLowerCase()))
-    for (const seeded of userData || []) {
-      if (existingAuthEmails.has(seeded.email.toLowerCase())) continue
-      const { error: createErr } = await supabase.auth.admin.createUser({
-        email: seeded.email,
-        password: SEED_USER_PASSWORD,
-        email_confirm: true,
-      })
-      if (createErr) throw new Error(`Failed to create auth user ${seeded.email}: ${createErr.message}`)
-      console.log(`  ✅ Created auth account for ${seeded.email}`)
-    }
-
     // Link freshly seeded public.users rows to their auth accounts. The seed
     // recreates rows with new ids; without auth_user_id the org-scoped RLS
     // policies hide every row from the logged-in user and login fails.


### PR DESCRIPTION
## Summary
Follow-up item #5 (+ the #7 one-liner):
1. **Org-scoped clearing** — every seeder delete/update now excludes `PRESERVED_ORG_NAMES` ('Trakr QA Sandbox'), so the persistent browser-QA org survives CI e2e runs (no more `seed:qa` after every merge). NULL-org rows still clear via `or()` filters (PostgREST `neq` drops NULLs).
2. **Phantom clears fixed** — `audit_photos`/`zone_branches` were 'cleared' with a `created_at` filter neither table has; the 'column does not exist' error matched `assertCleared`'s sloppy substring and got treated as missing-table, silently no-opping on every run while logging Postgres ERRORs. Their rows actually die via `ON DELETE CASCADE`, so they leave the list; the missing-table match is now anchored. `notifications` also cascades from `users`.
3. **Auth-user bootstrap** — `auth.admin.createUser` for any missing seeded account (default password matches `set-user-passwords.js`), making the seed fully self-contained on a fresh project — prerequisite for the dedicated e2e database (follow-up #6).
4. `createNotification`'s success log referenced `insert.data` (always null since #115's RETURNING removal) — logs identifying fields instead. This apps/web touch also forces full e2e here, which **executes the changed seeder against the live DB as its verification**.

## Verification plan
- CI e2e on this PR runs the new seeder end-to-end (seed step) + the full suite.
- Post-green: read-only check that the QA sandbox org and its 10 audits survived the reseed, then a browser login as a QA account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)