### PR TITLE
test(shared): wire packages/shared into CI with scoring characterization tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,13 @@ jobs:
       - name: Type check
         run: npm run type-check --workspace @trakr/shared && npm run type-check --workspace @trakr/web
 
-      - name: Unit tests
+      - name: Unit tests (web)
         run: npm run test:run --workspace @trakr/web
+
+      # packages/shared holds the compliance-scoring logic and had no CI test
+      # coverage before this step (the web unit step never reaches it). Gating.
+      - name: Unit tests (shared)
+        run: npm run test:run --workspace @trakr/shared
 
       - name: Build
         run: npm run build --workspace @trakr/web

--- a/package-lock.json
+++ b/package-lock.json
@@ -10676,7 +10676,8 @@
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "eslint": "^8.55.0",
-        "typescript": "^7.0.2"
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.10"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,9 @@
     "dev": "tsc --watch",
     "lint": "eslint src --ext .ts,.tsx",
     "type-check": "tsc --noEmit",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "date-fns": "^4.4.0"
@@ -20,7 +22,8 @@
     "typescript": "^7.0.2",
     "eslint": "^8.55.0",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
-    "@typescript-eslint/parser": "^6.14.0"
+    "@typescript-eslint/parser": "^6.14.0",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0"

--- a/packages/shared/src/utils/scoring.test.ts
+++ b/packages/shared/src/utils/scoring.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { calculateWeightedAuditScore } from './scoring'
+import { QuestionType } from '../types'
+import type { Audit, Survey, SurveyQuestion } from '../types'
+
+// Characterization tests for the weighted compliance score — the core metric.
+// These LOCK CURRENT BEHAVIOR (they are a regression net, not an assertion that
+// the behavior is ideal). Phase 2 expands this suite to the full case matrix and
+// adds separately-tagged repros for the flagged semantic decisions. This first
+// set exists so the new @trakr/shared CI step gates on real assertions: a broken
+// weight flip must turn the PR red.
+
+function q(id: string, over: Partial<SurveyQuestion> = {}): SurveyQuestion {
+  return {
+    id,
+    text: id,
+    type: QuestionType.YES_NO,
+    required: false,
+    order: 0,
+    isWeighted: true,
+    yesWeight: 10,
+    noWeight: 0,
+    ...over,
+  }
+}
+
+function survey(questions: SurveyQuestion[]): Survey {
+  return {
+    id: 's1', title: 't', description: '', version: 1, isActive: true,
+    createdBy: 'u', createdAt: new Date(0), updatedAt: new Date(0),
+    sections: [{ id: 'sec1', title: 'Section 1', questions, order: 0 }],
+  }
+}
+
+function audit(responses: Record<string, string>, overrideScores?: Record<string, number>): Audit {
+  return { responses, overrideScores } as unknown as Audit
+}
+
+describe('calculateWeightedAuditScore — characterization (current behavior locked)', () => {
+  it('all-compliant → 100% (yesWeight is the max)', () => {
+    const s = survey([q('q1'), q('q2')])
+    const a = audit({ q1: 'yes', q2: 'yes' })
+    expect(calculateWeightedAuditScore(a, s)).toEqual({
+      weightedPossiblePoints: 20,
+      weightedEarnedPoints: 20,
+      weightedCompliancePercentage: 100,
+    })
+  })
+
+  it('all-non-compliant → 0% (noWeight is 0)', () => {
+    const s = survey([q('q1'), q('q2')])
+    const a = audit({ q1: 'no', q2: 'no' })
+    expect(calculateWeightedAuditScore(a, s)).toEqual({
+      weightedPossiblePoints: 20,
+      weightedEarnedPoints: 0,
+      weightedCompliancePercentage: 0,
+    })
+  })
+
+  it('mixed one yes / one no → 50%', () => {
+    const s = survey([q('q1'), q('q2')])
+    const a = audit({ q1: 'yes', q2: 'no' })
+    expect(calculateWeightedAuditScore(a, s)).toEqual({
+      weightedPossiblePoints: 20,
+      weightedEarnedPoints: 10,
+      weightedCompliancePercentage: 50,
+    })
+  })
+})

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+// packages/shared holds pure business logic (compliance scoring, date utils).
+// It ran no tests in CI before — CI's only unit step is scoped to @trakr/web —
+// so scoring had zero coverage and a characterization test dropped here would
+// have been collected by nothing. Node environment: no DOM needed.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Phase 0 — regression-net plumbing (prerequisite)

`packages/shared` (home of `calculateWeightedAuditScore`, the compliance metric) had **no vitest runner and zero CI coverage** — the only unit step is scoped to `@trakr/web`. A characterization test dropped here would have run nowhere. This wires it up so every later scoring/hardening fix is provable on PRs.

- vitest + `test:run` added to `packages/shared` (node-env config)
- new **Unit tests (shared)** step inside the already-required `checks` job → gates PRs automatically (no ruleset change needed)
- first characterization tests locking current weighted-score behavior

**Gate proven red→green:** transiently flipping yes/no earning in `scoring.ts` turned the suite red (2 failed); revert restored 3/3 green. Phase 2 expands to the full case matrix + the flagged-semantics repros.

First step of the approved verification & hardening plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)