### PR TITLE
fix(rls): block auditor self-approval + BM raw status rewrite (audit integrity)

### DIFF
--- a/apps/web/tests/audit.illegal-transitions.spec.ts
+++ b/apps/web/tests/audit.illegal-transitions.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test'
+import {
+  getUserByEmail,
+  ensureBranchForOrg,
+  ensureSimpleSurvey,
+  ensureAuditorAssignedToBranch,
+  ensureBranchManagerAssigned,
+  ensureAuditFor,
+  getAuditStatus,
+  deleteAudits,
+  getUserClient,
+} from './helpers/e2eSetup'
+
+// Regression net for the audit state machine (Phase 1b). The `audits` UPDATE
+// RLS policy's WITH CHECK has no status constraint, so before the
+// enforce_audit_status_transition trigger a raw client UPDATE let an AUDITOR
+// self-approve their own audit (status->APPROVED) and skip set_audit_approval
+// entirely. These assert the illegal raw transitions now fail closed while the
+// legitimate auditor transition still succeeds. Phase 3 extends the net with
+// branch-manager / non-assignee / RPC-authz cases.
+test.describe('Audit illegal status transitions are blocked', () => {
+  test.setTimeout(120_000)
+
+  let orgId: string
+  let branchId: string
+  let surveyId: string
+  let auditorId: string
+  let managerId: string
+
+  test.beforeAll(async () => {
+    const auditor = await getUserByEmail('auditor@trakr.com')
+    const manager = await getUserByEmail('branchmanager@trakr.com')
+    if (!auditor || !manager) throw new Error('Seed users missing')
+    if (!manager.org_id) throw new Error('branchmanager@trakr.com has no org_id')
+    auditorId = auditor.id
+    managerId = manager.id
+    orgId = manager.org_id
+    const branch = await ensureBranchForOrg(orgId, 'E2E IllegalTransition Branch')
+    branchId = branch.id
+    const survey = await ensureSimpleSurvey(orgId, 'E2E IllegalTransition Survey')
+    surveyId = survey.id
+    await ensureAuditorAssignedToBranch(auditorId, branchId)
+    await ensureBranchManagerAssigned(managerId, branchId)
+  })
+
+  const createdAuditIds: string[] = []
+  test.afterAll(async () => {
+    await deleteAudits(createdAuditIds)
+  })
+
+  test('auditor CANNOT self-approve their own audit via a raw status update', async () => {
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId) // DRAFT
+    createdAuditIds.push(audit.id)
+    const supa = await getUserClient('auditor@trakr.com', 'Password@123')
+    const { error } = await supa.from('audits').update({ status: 'APPROVED' }).eq('id', audit.id)
+    expect(error, 'trigger must reject auditor self-approval').toBeTruthy()
+    expect(await getAuditStatus(audit.id)).toBe('DRAFT')
+  })
+
+  test('auditor CANNOT self-submit via a raw status update (must use submit_audit)', async () => {
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId) // DRAFT
+    createdAuditIds.push(audit.id)
+    const supa = await getUserClient('auditor@trakr.com', 'Password@123')
+    const { error } = await supa.from('audits').update({ status: 'SUBMITTED' }).eq('id', audit.id)
+    expect(error, 'trigger must reject raw SUBMITTED transition').toBeTruthy()
+    expect(await getAuditStatus(audit.id)).toBe('DRAFT')
+  })
+
+  test('auditor CAN still complete their own audit (legit transition preserved)', async () => {
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId) // DRAFT
+    createdAuditIds.push(audit.id)
+    const supa = await getUserClient('auditor@trakr.com', 'Password@123')
+    const { error } = await supa.from('audits').update({ status: 'COMPLETED' }).eq('id', audit.id)
+    expect(error, 'auditor DRAFT->COMPLETED must remain allowed').toBeFalsy()
+    expect(await getAuditStatus(audit.id)).toBe('COMPLETED')
+  })
+})

--- a/supabase/migrations/20260722094148_enforce_audit_status_transition_guard.sql
+++ b/supabase/migrations/20260722094148_enforce_audit_status_transition_guard.sql
@@ -1,0 +1,36 @@
+-- The audits UPDATE RLS policy's WITH CHECK imposes no status constraint, so a
+-- raw client UPDATE lets an AUDITOR self-approve their own audit
+-- (status->APPROVED) and a BRANCH_MANAGER rewrite the status of a finalized
+-- audit -- both bypassing set_audit_approval's guards (self-approval block,
+-- WHERE status='SUBMITTED', signature capture). WITH CHECK cannot see OLD.status
+-- to express "legal transition", so enforce the state machine with a trigger.
+-- SECURITY INVOKER (not DEFINER) so current_user reflects the real caller:
+-- raw PostgREST calls run as 'authenticated'; the SECURITY DEFINER RPCs
+-- (submit_audit, set_audit_approval) run as 'postgres' and pass through, as do
+-- service_role/admin paths. Verified via role-switched rollback transactions:
+-- auditor DRAFT->IN_PROGRESS allowed; auditor->APPROVED blocked; BM raw approve
+-- blocked; postgres/RPC path allowed.
+CREATE OR REPLACE FUNCTION public.enforce_audit_status_transition()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO 'public', 'pg_temp' AS $fn$
+BEGIN
+  IF NEW.status IS NOT DISTINCT FROM OLD.status THEN
+    RETURN NEW; -- content-only edits are not status transitions
+  END IF;
+  IF current_user NOT IN ('authenticated', 'anon') THEN
+    RETURN NEW; -- SECURITY DEFINER RPCs / service_role / admin-cli
+  END IF;
+  IF public.current_user_role() = 'AUDITOR'::user_role THEN
+    IF NEW.status = ANY (ARRAY['DRAFT','IN_PROGRESS','COMPLETED']::audit_status[]) THEN
+      RETURN NEW; -- auditor edit/complete; never SUBMITTED/APPROVED/REJECTED via raw update
+    END IF;
+  ELSIF public.current_user_role() = ANY (ARRAY['ADMIN','SUPER_ADMIN']::user_role[]) THEN
+    RETURN NEW; -- trusted org operators
+  END IF;
+  RAISE EXCEPTION 'Illegal audit status transition % -> % via direct update; decisions must go through submit_audit / set_audit_approval', OLD.status, NEW.status
+    USING ERRCODE = '42501';
+END $fn$;
+
+DROP TRIGGER IF EXISTS trg_enforce_audit_status_transition ON public.audits;
+CREATE TRIGGER trg_enforce_audit_status_transition
+  BEFORE UPDATE ON public.audits
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_audit_status_transition();


### PR DESCRIPTION
## Phase 1b — CRITICAL audit-integrity gap

`audits_update_policy`'s `WITH CHECK` imposes **no status constraint**, so a raw client `update({status:'APPROVED'})` let an **auditor self-approve their own audit** and a **branch manager rewrite any finalized audit's status** — bypassing every guard in `set_audit_approval` (self-approval block, `WHERE status='SUBMITTED'`, signature capture). Compliance-fraud vector on a live bank pilot.

`WITH CHECK` can't see `OLD.status` to express a legal transition, so this adds a **`BEFORE UPDATE` trigger** (SECURITY INVOKER, so `current_user` distinguishes a raw `authenticated` call from a SECURITY DEFINER RPC running as `postgres`). Raw client status changes are constrained (auditor → only DRAFT/IN_PROGRESS/COMPLETED; nobody else raw-changes status); `submit_audit`/`set_audit_approval` and service_role pass through untouched. RLS is left intact (it already handles org/ownership).

## Proof (red → green, on the live DB)
- **Red:** with the trigger dropped in a rollback tx, an auditor's raw  **succeeds**.
- **Green:** with the trigger, role-switched rollback tests → auditor self-approve blocked, BM raw-approve blocked, legit auditor DRAFT→IN_PROGRESS/→COMPLETED allowed, postgres/RPC path allowed.
- New `audit.illegal-transitions.spec.ts` (authenticated-client integration) **3/3 green**: self-approve blocked, self-submit blocked, legit →COMPLETED preserved.

Migration applied live (stamp `20260722094148`) after non-persisting rollback-tx verification; committed here for repo/DB parity. Phase 3 extends the negative net (BM/non-assignee/RPC-authz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)