### PR TITLE
fix(rls): org-authorize the unguarded SECURITY DEFINER audit/assignment RPCs

### DIFF
--- a/apps/web/tests/audit.rpc-authorization.spec.ts
+++ b/apps/web/tests/audit.rpc-authorization.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import {
+  getUserByEmail,
+  ensureBranchForOrg,
+  ensureSimpleSurvey,
+  ensureAuditorAssignedToBranch,
+  ensureBranchManagerAssigned,
+  ensureAuditFor,
+  getAuditStatus,
+  deleteAudits,
+  getUserClient,
+} from './helpers/e2eSetup'
+
+// Regression net for Phase 1c: the SECURITY DEFINER RPCs (submit_audit,
+// set_auditor_assignment, reassign_*, set_audit_assigned_to) bypass RLS and
+// were callable by any authenticated user with NO org/role authorization.
+// Cross-org denial is proven by role-switched rollback transactions in the
+// migration; these single-org integration tests assert the in-org
+// authorization (admin-only ops reject non-admins; submit requires the
+// assigned auditor or an admin) while the legitimate path still works.
+test.describe('SECURITY DEFINER RPC authorization', () => {
+  test.setTimeout(120_000)
+
+  let orgId: string
+  let branchId: string
+  let surveyId: string
+  let auditorId: string
+  let managerId: string
+
+  test.beforeAll(async () => {
+    const auditor = await getUserByEmail('auditor@trakr.com')
+    const manager = await getUserByEmail('branchmanager@trakr.com')
+    if (!auditor || !manager) throw new Error('Seed users missing')
+    if (!manager.org_id) throw new Error('branchmanager@trakr.com has no org_id')
+    auditorId = auditor.id
+    managerId = manager.id
+    orgId = manager.org_id
+    const branch = await ensureBranchForOrg(orgId, 'E2E RpcAuthz Branch')
+    branchId = branch.id
+    const survey = await ensureSimpleSurvey(orgId, 'E2E RpcAuthz Survey')
+    surveyId = survey.id
+    await ensureAuditorAssignedToBranch(auditorId, branchId)
+    await ensureBranchManagerAssigned(managerId, branchId)
+  })
+
+  const createdAuditIds: string[] = []
+  test.afterAll(async () => {
+    await deleteAudits(createdAuditIds)
+  })
+
+  test('a non-admin (auditor) CANNOT call set_auditor_assignment', async () => {
+    const supa = await getUserClient('auditor@trakr.com', 'Password@123')
+    const { error } = await supa.rpc('set_auditor_assignment', {
+      p_user_id: auditorId, p_branch_ids: [branchId], p_zone_ids: [],
+    })
+    expect(error, 'set_auditor_assignment must reject a non-admin caller').toBeTruthy()
+  })
+
+  test('a branch manager (non-assignee, non-admin) CANNOT submit another user\'s audit', async () => {
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId) // DRAFT, assigned to auditor
+    createdAuditIds.push(audit.id)
+    const supa = await getUserClient('branchmanager@trakr.com', 'Password@123')
+    const { error } = await supa.rpc('submit_audit', { p_audit_id: audit.id, p_submitted_by: managerId })
+    expect(error, 'submit_audit must reject a non-assignee non-admin').toBeTruthy()
+    expect(await getAuditStatus(audit.id)).toBe('DRAFT')
+  })
+
+  test('the assigned auditor CAN submit their own audit via submit_audit (legit path)', async () => {
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId) // DRAFT
+    createdAuditIds.push(audit.id)
+    const supa = await getUserClient('auditor@trakr.com', 'Password@123')
+    const { error } = await supa.rpc('submit_audit', { p_audit_id: audit.id, p_submitted_by: auditorId })
+    expect(error, 'assigned auditor submit must succeed').toBeFalsy()
+    expect(await getAuditStatus(audit.id)).toBe('SUBMITTED')
+  })
+})

--- a/supabase/migrations/20260722100541_org_authorize_security_definer_rpcs.sql
+++ b/supabase/migrations/20260722100541_org_authorize_security_definer_rpcs.sql
@@ -1,0 +1,122 @@
+-- These SECURITY DEFINER RPCs (RLS-bypassing, granted to authenticated, callable
+-- via PostgREST) performed NO org-authorization: a user in org A could reassign/
+-- submit org B's audits and rewrite org B users' branch/zone assignments. Add
+-- org + role guards mirroring create_audit_with_cycle_guard, derive submit_audit's
+-- submitter from auth.uid(), and pin search_path on the three that lacked it.
+-- Verified with role-switched rollback transactions (cross-org blocked, in-org
+-- allowed, assigned-auditor submit allowed, non-assignee submit blocked).
+
+CREATE OR REPLACE FUNCTION public.reassign_open_audits_for_branch(p_branch_id uuid, p_to_user uuid)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+DECLARE v_count integer;
+BEGIN
+  IF NOT public.is_admin_or_super() THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  IF NOT public.is_super_admin() AND (
+       (SELECT org_id FROM public.branches WHERE id=p_branch_id) IS DISTINCT FROM public.current_user_org_id()
+       OR (SELECT org_id FROM public.users WHERE id=p_to_user) IS DISTINCT FROM public.current_user_org_id()) THEN
+    RAISE EXCEPTION 'Cross-org reassignment denied' USING ERRCODE='42501';
+  END IF;
+  UPDATE public.audits SET assigned_to=p_to_user, updated_at=now()
+   WHERE branch_id=p_branch_id AND is_archived=false AND status IN ('DRAFT','IN_PROGRESS','REJECTED');
+  GET DIAGNOSTICS v_count=ROW_COUNT; RETURN COALESCE(v_count,0);
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.reassign_open_audits_for_branches(p_branch_ids uuid[], p_to_user uuid)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+DECLARE total int := 0; bid uuid;
+BEGIN
+  IF NOT public.is_admin_or_super() THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  FOREACH bid IN ARRAY COALESCE(p_branch_ids, ARRAY[]::uuid[]) LOOP
+    total := total + public.reassign_open_audits_for_branch(bid, p_to_user); -- inner enforces per-branch org
+  END LOOP;
+  RETURN total;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.reassign_unstarted_audits_for_branches(p_branch_ids uuid[], p_to_user uuid)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+DECLARE v_count integer;
+BEGIN
+  IF NOT public.is_admin_or_super() THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  IF NOT public.is_super_admin() AND (
+       EXISTS (SELECT 1 FROM public.branches WHERE id = ANY(COALESCE(p_branch_ids, ARRAY[]::uuid[])) AND org_id IS DISTINCT FROM public.current_user_org_id())
+       OR (SELECT org_id FROM public.users WHERE id=p_to_user) IS DISTINCT FROM public.current_user_org_id()) THEN
+    RAISE EXCEPTION 'Cross-org reassignment denied' USING ERRCODE='42501';
+  END IF;
+  UPDATE public.audits SET assigned_to=p_to_user, updated_at=now()
+   WHERE branch_id = ANY(COALESCE(p_branch_ids, ARRAY[]::uuid[])) AND is_archived=false AND status='DRAFT';
+  GET DIAGNOSTICS v_count=ROW_COUNT; RETURN COALESCE(v_count,0);
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.set_audit_assigned_to(p_audit_id uuid, p_to_user uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN
+  IF NOT public.is_admin_or_super() THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  IF NOT public.is_super_admin() AND (
+       (SELECT org_id FROM public.audits WHERE id=p_audit_id) IS DISTINCT FROM public.current_user_org_id()
+       OR (SELECT org_id FROM public.users WHERE id=p_to_user) IS DISTINCT FROM public.current_user_org_id()) THEN
+    RAISE EXCEPTION 'Cross-org reassignment denied' USING ERRCODE='42501';
+  END IF;
+  UPDATE public.audits SET assigned_to=p_to_user, updated_at=now()
+   WHERE id=p_audit_id AND is_archived=false AND status IN ('DRAFT','IN_PROGRESS','REJECTED');
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.set_auditor_assignment(p_user_id uuid, p_branch_ids uuid[], p_zone_ids uuid[])
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN
+  IF NOT public.is_admin_or_super() THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  IF NOT public.is_super_admin() AND (
+       (SELECT org_id FROM public.users WHERE id=p_user_id) IS DISTINCT FROM public.current_user_org_id()
+       OR EXISTS (SELECT 1 FROM public.branches WHERE id = ANY(COALESCE(p_branch_ids, ARRAY[]::uuid[])) AND org_id IS DISTINCT FROM public.current_user_org_id())
+       OR EXISTS (SELECT 1 FROM public.zones WHERE id = ANY(COALESCE(p_zone_ids, ARRAY[]::uuid[])) AND org_id IS DISTINCT FROM public.current_user_org_id())) THEN
+    RAISE EXCEPTION 'Cross-org assignment denied' USING ERRCODE='42501';
+  END IF;
+  DELETE FROM public.zone_assignments WHERE user_id = p_user_id;
+  INSERT INTO public.zone_assignments (id, created_at, created_by, org_id, user_id, zone_id)
+  SELECT gen_random_uuid(), now(), p_user_id, u.org_id, p_user_id, z_id
+  FROM public.users u, unnest(COALESCE(p_zone_ids, ARRAY[]::uuid[])) AS z_id WHERE u.id = p_user_id;
+  DELETE FROM public.auditor_branch_assignments WHERE user_id = p_user_id;
+  INSERT INTO public.auditor_branch_assignments (id, created_at, created_by, org_id, user_id, branch_id, period_start, period_end)
+  SELECT gen_random_uuid(), now(), p_user_id, u.org_id, p_user_id, b_id,
+         date_trunc('day', now())::timestamptz, (now() + interval '90 days')
+  FROM public.users u, unnest(COALESCE(p_branch_ids, ARRAY[]::uuid[])) AS b_id WHERE u.id = p_user_id;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.remove_branch_from_auditor_assignments(p_branch_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN
+  IF NOT public.is_admin_or_super() THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  UPDATE public.auditor_assignments SET branch_ids=array_remove(branch_ids,p_branch_id), updated_at=now()
+   WHERE branch_ids @> ARRAY[p_branch_id] AND (public.is_super_admin() OR org_id = public.current_user_org_id());
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.remove_zone_from_auditor_assignments(p_zone_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN
+  IF NOT public.is_admin_or_super() THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  UPDATE public.auditor_assignments SET zone_ids=array_remove(zone_ids,p_zone_id), updated_at=now()
+   WHERE zone_ids @> ARRAY[p_zone_id] AND (public.is_super_admin() OR org_id = public.current_user_org_id());
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.submit_audit(p_audit_id uuid, p_submitted_by uuid)
+RETURNS audits LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+declare v_audit public.audits; v_result public.audits; v_now timestamptz := timezone('utc', now());
+begin
+  select * into v_audit from public.audits where id = p_audit_id;
+  if not found then raise exception 'Audit % not found', p_audit_id using errcode='P0002'; end if;
+  if not public.is_super_admin() then
+    if v_audit.org_id is distinct from public.current_user_org_id() then
+      raise exception 'Not authorized for this audit' using errcode='42501';
+    end if;
+    if not (public.is_admin_or_super() or v_audit.assigned_to = public.current_user_id()) then
+      raise exception 'Only the assigned auditor or an admin can submit this audit' using errcode='42501';
+    end if;
+  end if;
+  update public.audits
+     set status='SUBMITTED',
+         submitted_by = coalesce(public.current_user_id(), p_submitted_by, submitted_by),
+         submitted_at = v_now, updated_at = v_now
+   where id = p_audit_id and status in ('DRAFT','IN_PROGRESS','COMPLETED')
+  returning * into v_result;
+  if not found then v_result := v_audit; end if;
+  return v_result;
+end $fn$;

--- a/supabase/migrations/20260722101613_org_authorize_secdef_rpcs_allow_service_role.sql
+++ b/supabase/migrations/20260722101613_org_authorize_secdef_rpcs_allow_service_role.sql
@@ -1,0 +1,121 @@
+-- Correction to 20260722100541: those guards used only is_admin_or_super(),
+-- which reads auth.uid() and is false for the service_role backend key
+-- (auth.uid() is null). That wrongly blocked the trusted backend paths (seeder,
+-- edge functions, e2e helpers) which legitimately administer via service_role.
+-- Allow service_role (never exposed to browsers) alongside an in-org admin; a
+-- plain authenticated non-admin is still rejected and cross-org still denied.
+
+CREATE OR REPLACE FUNCTION public.reassign_open_audits_for_branch(p_branch_id uuid, p_to_user uuid)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+DECLARE v_count integer;
+BEGIN
+  IF NOT (public.is_admin_or_super() OR auth.role() = 'service_role') THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  IF NOT (public.is_super_admin() OR auth.role() = 'service_role') AND (
+       (SELECT org_id FROM public.branches WHERE id=p_branch_id) IS DISTINCT FROM public.current_user_org_id()
+       OR (SELECT org_id FROM public.users WHERE id=p_to_user) IS DISTINCT FROM public.current_user_org_id()) THEN
+    RAISE EXCEPTION 'Cross-org reassignment denied' USING ERRCODE='42501';
+  END IF;
+  UPDATE public.audits SET assigned_to=p_to_user, updated_at=now()
+   WHERE branch_id=p_branch_id AND is_archived=false AND status IN ('DRAFT','IN_PROGRESS','REJECTED');
+  GET DIAGNOSTICS v_count=ROW_COUNT; RETURN COALESCE(v_count,0);
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.reassign_open_audits_for_branches(p_branch_ids uuid[], p_to_user uuid)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+DECLARE total int := 0; bid uuid;
+BEGIN
+  IF NOT (public.is_admin_or_super() OR auth.role() = 'service_role') THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  FOREACH bid IN ARRAY COALESCE(p_branch_ids, ARRAY[]::uuid[]) LOOP
+    total := total + public.reassign_open_audits_for_branch(bid, p_to_user);
+  END LOOP;
+  RETURN total;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.reassign_unstarted_audits_for_branches(p_branch_ids uuid[], p_to_user uuid)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+DECLARE v_count integer;
+BEGIN
+  IF NOT (public.is_admin_or_super() OR auth.role() = 'service_role') THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  IF NOT (public.is_super_admin() OR auth.role() = 'service_role') AND (
+       EXISTS (SELECT 1 FROM public.branches WHERE id = ANY(COALESCE(p_branch_ids, ARRAY[]::uuid[])) AND org_id IS DISTINCT FROM public.current_user_org_id())
+       OR (SELECT org_id FROM public.users WHERE id=p_to_user) IS DISTINCT FROM public.current_user_org_id()) THEN
+    RAISE EXCEPTION 'Cross-org reassignment denied' USING ERRCODE='42501';
+  END IF;
+  UPDATE public.audits SET assigned_to=p_to_user, updated_at=now()
+   WHERE branch_id = ANY(COALESCE(p_branch_ids, ARRAY[]::uuid[])) AND is_archived=false AND status='DRAFT';
+  GET DIAGNOSTICS v_count=ROW_COUNT; RETURN COALESCE(v_count,0);
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.set_audit_assigned_to(p_audit_id uuid, p_to_user uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN
+  IF NOT (public.is_admin_or_super() OR auth.role() = 'service_role') THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  IF NOT (public.is_super_admin() OR auth.role() = 'service_role') AND (
+       (SELECT org_id FROM public.audits WHERE id=p_audit_id) IS DISTINCT FROM public.current_user_org_id()
+       OR (SELECT org_id FROM public.users WHERE id=p_to_user) IS DISTINCT FROM public.current_user_org_id()) THEN
+    RAISE EXCEPTION 'Cross-org reassignment denied' USING ERRCODE='42501';
+  END IF;
+  UPDATE public.audits SET assigned_to=p_to_user, updated_at=now()
+   WHERE id=p_audit_id AND is_archived=false AND status IN ('DRAFT','IN_PROGRESS','REJECTED');
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.set_auditor_assignment(p_user_id uuid, p_branch_ids uuid[], p_zone_ids uuid[])
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN
+  IF NOT (public.is_admin_or_super() OR auth.role() = 'service_role') THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  IF NOT (public.is_super_admin() OR auth.role() = 'service_role') AND (
+       (SELECT org_id FROM public.users WHERE id=p_user_id) IS DISTINCT FROM public.current_user_org_id()
+       OR EXISTS (SELECT 1 FROM public.branches WHERE id = ANY(COALESCE(p_branch_ids, ARRAY[]::uuid[])) AND org_id IS DISTINCT FROM public.current_user_org_id())
+       OR EXISTS (SELECT 1 FROM public.zones WHERE id = ANY(COALESCE(p_zone_ids, ARRAY[]::uuid[])) AND org_id IS DISTINCT FROM public.current_user_org_id())) THEN
+    RAISE EXCEPTION 'Cross-org assignment denied' USING ERRCODE='42501';
+  END IF;
+  DELETE FROM public.zone_assignments WHERE user_id = p_user_id;
+  INSERT INTO public.zone_assignments (id, created_at, created_by, org_id, user_id, zone_id)
+  SELECT gen_random_uuid(), now(), p_user_id, u.org_id, p_user_id, z_id
+  FROM public.users u, unnest(COALESCE(p_zone_ids, ARRAY[]::uuid[])) AS z_id WHERE u.id = p_user_id;
+  DELETE FROM public.auditor_branch_assignments WHERE user_id = p_user_id;
+  INSERT INTO public.auditor_branch_assignments (id, created_at, created_by, org_id, user_id, branch_id, period_start, period_end)
+  SELECT gen_random_uuid(), now(), p_user_id, u.org_id, p_user_id, b_id,
+         date_trunc('day', now())::timestamptz, (now() + interval '90 days')
+  FROM public.users u, unnest(COALESCE(p_branch_ids, ARRAY[]::uuid[])) AS b_id WHERE u.id = p_user_id;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.remove_branch_from_auditor_assignments(p_branch_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN
+  IF NOT (public.is_admin_or_super() OR auth.role() = 'service_role') THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  UPDATE public.auditor_assignments SET branch_ids=array_remove(branch_ids,p_branch_id), updated_at=now()
+   WHERE branch_ids @> ARRAY[p_branch_id] AND (public.is_super_admin() OR auth.role() = 'service_role' OR org_id = public.current_user_org_id());
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.remove_zone_from_auditor_assignments(p_zone_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+BEGIN
+  IF NOT (public.is_admin_or_super() OR auth.role() = 'service_role') THEN RAISE EXCEPTION 'Not authorized' USING ERRCODE='42501'; END IF;
+  UPDATE public.auditor_assignments SET zone_ids=array_remove(zone_ids,p_zone_id), updated_at=now()
+   WHERE zone_ids @> ARRAY[p_zone_id] AND (public.is_super_admin() OR auth.role() = 'service_role' OR org_id = public.current_user_org_id());
+END $fn$;
+
+CREATE OR REPLACE FUNCTION public.submit_audit(p_audit_id uuid, p_submitted_by uuid)
+RETURNS audits LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $fn$
+declare v_audit public.audits; v_result public.audits; v_now timestamptz := timezone('utc', now());
+begin
+  select * into v_audit from public.audits where id = p_audit_id;
+  if not found then raise exception 'Audit % not found', p_audit_id using errcode='P0002'; end if;
+  if not (public.is_super_admin() or auth.role() = 'service_role') then
+    if v_audit.org_id is distinct from public.current_user_org_id() then
+      raise exception 'Not authorized for this audit' using errcode='42501';
+    end if;
+    if not (public.is_admin_or_super() or v_audit.assigned_to = public.current_user_id()) then
+      raise exception 'Only the assigned auditor or an admin can submit this audit' using errcode='42501';
+    end if;
+  end if;
+  update public.audits
+     set status='SUBMITTED',
+         submitted_by = coalesce(public.current_user_id(), p_submitted_by, submitted_by),
+         submitted_at = v_now, updated_at = v_now
+   where id = p_audit_id and status in ('DRAFT','IN_PROGRESS','COMPLETED')
+  returning * into v_result;
+  if not found then v_result := v_audit; end if;
+  return v_result;
+end $fn$;


### PR DESCRIPTION
## Phase 1c — HIGH cross-tenant vector via SECURITY DEFINER RPCs

Eight SECURITY DEFINER RPCs (RLS-bypassing, granted to `authenticated`, callable via PostgREST) had **no org authorization** — a user in org A could reassign/submit org B's audits and rewrite org B users' branch/zone assignments.

Guards added mirror `create_audit_with_cycle_guard`: in-org admin (or super cross-org), cross-org targets rejected; `submit_audit` requires the assigned auditor or an admin and derives `submitted_by` from `auth.uid()`. `search_path` pinned on the three flagged functions (clears `function_search_path_mutable`). The trusted **service_role** backend is allowed via `auth.role()` — the two migration stamps are the initial guard + a correction (the first cut only checked `is_admin_or_super()`, false for service_role, which broke the seeder/edge/e2e path).

## Proof
- Role-switched rollback transactions on the live DB: cross-org assignment **blocked**, in-org allowed, assigned-auditor submit allowed, non-assignee submit **blocked**.
- `get_advisors(security)`: zero `function_search_path_mutable` (remaining `*_security_definer_function_executable` warnings are by-design — these RPCs are meant to be called by authenticated users and now self-authorize).
- New `audit.rpc-authorization.spec.ts` **3/3 green** (non-admin can't assign, non-assignee can't submit, assignee can) + `audit.illegal-transitions` still 3/3.

Migrations applied live (stamps `20260722100541`+`20260722101613`) after rollback-tx verification; committed for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)