### PR TITLE
test(audit): extend illegal-transition net + document the state machine

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,11 +101,22 @@ DRAFT → IN_PROGRESS → COMPLETED → SUBMITTED → APPROVED
                                    REJECTED
 ```
 
-- No `FINALIZED` state — removed as dead code.
-- Client single source of truth: `apps/web/src/hooks/useAuditStateMachine.ts` maps (status, role, completion%) → permissions (canEdit/canSubmit/canDelete/canReopen + user guidance).
-- Auditor: edits DRAFT/IN_PROGRESS/COMPLETED/REJECTED; submit requires 100% completion; SUBMITTED/APPROVED are read-only.
-- Branch manager: review-only; approve/reject SUBMITTED (DB-side role guard `enforce_approval_role_guard`, `set_audit_approval` function; rejection data preserved on later approval).
-- DB guards: `create_audit_guard`, `submit_audit` RPC (returns audit), scheduled-audit auditor enforcement.
+Enum: `DRAFT, IN_PROGRESS, COMPLETED, SUBMITTED, APPROVED, REJECTED`. No `FINALIZED` (removed as dead code).
+
+**Transition table (from → to · who · sanctioned path · enforcement).** The DB is the source of truth; the client hook mirrors it for UX.
+
+| From | To | Who | Sanctioned path | DB enforcement |
+|---|---|---|---|---|
+| DRAFT | IN_PROGRESS | assigned auditor | `saveAuditProgress` (raw UPDATE) | `enforce_audit_status_transition` trigger allows AUDITOR → {DRAFT,IN_PROGRESS,COMPLETED} |
+| IN_PROGRESS | COMPLETED | assigned auditor | `setAuditStatus` (raw UPDATE, filtered from DRAFT/IN_PROGRESS) | same trigger |
+| DRAFT/IN_PROGRESS/COMPLETED | SUBMITTED | assigned auditor or admin | `submit_audit` RPC (SECURITY DEFINER) | RPC: org + assignee/admin check; `submitted_by` from `auth.uid()`. Raw client `→SUBMITTED` is **blocked** by the trigger |
+| SUBMITTED | APPROVED | assigned branch manager or admin (never the auditor) | `set_audit_approval('approved')` RPC | RPC: org + assigned-BM/admin, own-auditor block, `WHERE status='SUBMITTED'` (race guard). Raw client status write **blocked** by the trigger |
+| SUBMITTED | REJECTED | assigned branch manager or admin | `set_audit_approval('rejected')` RPC | same RPC guards |
+| REJECTED | IN_PROGRESS | assigned auditor | `saveAuditProgress` (resubmit edit) | trigger allows AUDITOR → editable states |
+
+- **The only sanctioned status-transition paths are `submit_audit` and `set_audit_approval`.** Raw client `status` writes are constrained by the `enforce_audit_status_transition` trigger (SECURITY INVOKER, migration `20260722094148`): an AUDITOR may reach only {DRAFT,IN_PROGRESS,COMPLETED}; ADMIN/SUPER_ADMIN pass; the SECURITY DEFINER RPCs and service_role pass (they run as `postgres`). This closes the auditor-self-approve and BM-raw-rewrite vectors (a raw `WITH CHECK` can't see `OLD.status`).
+- Client single source of truth: `apps/web/src/hooks/useAuditStateMachine.ts` maps (status, role, completion%) → permissions (canEdit/canSubmit/canDelete/canReopen + guidance). Auditor submit requires 100% completion; SUBMITTED/APPROVED are read-only client-side. Rejection data is preserved on later approval.
+- Negative regression net: `apps/web/tests/audit.illegal-transitions.spec.ts` (auditor self-approve/self-submit blocked, BM raw rewrite of APPROVED blocked, non-BM RPC approval denied) and `audit.rpc-authorization.spec.ts` (RPC org/assignee authz); the happy path is `audit.approval-flow.spec.ts` (incl. the double-approval race guard).
 
 ## 6. Data Model Highlights
 
@@ -125,8 +136,10 @@ Scoring: weighted-only compliance via `calculateWeightedAuditScore()` in `@trakr
 
 ## 7. Storage
 
-- Buckets: `audit-photos`, `profile-media` — public buckets, reads via public URLs.
-- Writes: authenticated-only (post-hardening), 10MB object limit, image MIME allowlist.
+- Buckets: `audit-photos`, `profile-media` — **private** (org-partitioned), 10MB object limit. A public bucket is internet-readable regardless of RLS, so both were privatized (migrations `20260722110610`, `20260722123651`).
+- Paths encode the owning entity so `storage.objects` policies can org-scope: `audit-photos` → `audits/<auditId>/…`; `profile-media` → `<avatars|signatures>/<userId>/…`.
+- Access: `audit_photos_*` policies gate on `storage_audit_in_my_org()` (org membership); `profile_media_*` gate on same-org **read** / own-only **write** (`current_user_id()`). Both helpers are SECURITY DEFINER (bypass row-RLS to check org), search_path-pinned, anon EXECUTE revoked.
+- Reads: the app stores the object **path** and mints a short-lived **signed URL** on read via `utils/signedUrls.ts` + `useSignedUrl` + `<SignedImage>` (signed at display time, not fetch time — the persisted React Query cache would otherwise store expired URLs). `data:`/`blob:`/`http` values pass through untouched. The PDF signs inline before embedding.
 
 ## 8. Edge Functions (`supabase/functions/`)
 

--- a/apps/web/tests/audit.illegal-transitions.spec.ts
+++ b/apps/web/tests/audit.illegal-transitions.spec.ts
@@ -6,6 +6,8 @@ import {
   ensureAuditorAssignedToBranch,
   ensureBranchManagerAssigned,
   ensureAuditFor,
+  setAuditSubmitted,
+  setAuditApproved,
   getAuditStatus,
   deleteAudits,
   getUserClient,
@@ -73,5 +75,37 @@ test.describe('Audit illegal status transitions are blocked', () => {
     const { error } = await supa.from('audits').update({ status: 'COMPLETED' }).eq('id', audit.id)
     expect(error, 'auditor DRAFT->COMPLETED must remain allowed').toBeFalsy()
     expect(await getAuditStatus(audit.id)).toBe('COMPLETED')
+  })
+
+  test('a branch manager CANNOT raw-rewrite the status of an APPROVED audit', async () => {
+    // A finalized (APPROVED) audit must not be un-approved or re-decided by a raw
+    // client UPDATE; decisions flow only through set_audit_approval. The trigger
+    // blocks any BRANCH_MANAGER raw status change.
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId)
+    createdAuditIds.push(audit.id)
+    await setAuditSubmitted(audit.id, auditorId)
+    await setAuditApproved(audit.id, managerId)
+    expect(await getAuditStatus(audit.id)).toBe('APPROVED')
+
+    const supa = await getUserClient('branchmanager@trakr.com', 'Password@123')
+    const { error } = await supa.from('audits').update({ status: 'REJECTED' }).eq('id', audit.id)
+    expect(error, 'trigger must block a BM raw status rewrite of an APPROVED audit').toBeTruthy()
+    expect(await getAuditStatus(audit.id)).toBe('APPROVED')
+  })
+
+  test('a non-BM, non-admin user CANNOT approve via set_audit_approval', async () => {
+    // set_audit_approval only lets the assigned branch manager (or an admin)
+    // decide. The assigned auditor is neither, so their RPC call is rejected and
+    // the audit stays SUBMITTED.
+    const audit = await ensureAuditFor(auditorId, orgId, branchId, surveyId)
+    createdAuditIds.push(audit.id)
+    await setAuditSubmitted(audit.id, auditorId)
+
+    const supa = await getUserClient('auditor@trakr.com', 'Password@123')
+    const { error } = await supa.rpc('set_audit_approval', {
+      p_audit_id: audit.id, p_status: 'approved', p_user_id: auditorId,
+    })
+    expect(error, 'set_audit_approval must reject a non-BM non-admin approver').toBeTruthy()
+    expect(await getAuditStatus(audit.id)).toBe('SUBMITTED')
   })
 })

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,6 +2,11 @@
 
 Running log of engineering decisions (newest first). One entry per decision: date, what, why.
 
+## 2026-07-22 — Audit state machine: negative net + transition table (Phase 3)
+- The **enforcement** already shipped (1b trigger + 1c RPC guards); Phase 3 completes the **regression net** and the **documentation**. The canonical transition table (from→to · who · sanctioned path · DB enforcement) now lives in `ARCHITECTURE.md §5` — the single sanctioned status-transition paths are `submit_audit` and `set_audit_approval`; all raw client `status` writes are constrained by the `enforce_audit_status_transition` trigger.
+- Extended `audit.illegal-transitions.spec.ts` with the two remaining illegal moves: a **BM cannot raw-rewrite an APPROVED audit's status** (trigger blocks any BRANCH_MANAGER raw status change) and a **non-BM/non-admin cannot approve via `set_audit_approval`** (the assigned auditor is neither the assigned BM nor an admin). Both green (5/5). The double-approval race guard was already covered by `audit.approval-flow.spec.ts`, so it was not duplicated.
+- Also brought `ARCHITECTURE.md §7 (Storage)` current with the 1a privatization (was still describing public buckets).
+
 ## 2026-07-22 — Storage isolation, part 2: privatize profile-media (Phase 1a-2)
 - Privatized the `profile-media` bucket (avatars + signatures) and org-scoped it, reusing the 1a-1 signing infra (`<SignedImage>` + `useSignedUrl`) across **17 display sites** (7 avatar components, 3 signature sites, the approval-signature panel). Both media buckets are now private and org-partitioned; no bucket-only storage policy remains.
 - **Path scheme changed** to `<prefix>/<userId>/...` (clean folder segment) — safe because there was zero stored profile-media data. Writes are **own-only** (`folder[2] = current_user_id()`); reads are **same-org** (via `storage_user_in_my_org()` SECURITY DEFINER, mirroring `storage_audit_in_my_org`). All `setUserAvatar`/`setUserSignature` callers pass `user.id` (self), so own-only writes break nothing. Approval signatures render through the same resolver — drawn ones are inline `data:` URLs (pass-through), image-mode ones are profile-media paths (signed).


### PR DESCRIPTION
## Phase 3 — Audit state machine: negative net + transition table

The **enforcement** already shipped (1b status-transition trigger #125, 1c RPC org-guards #126). This phase completes the **regression net** and the **documentation** — no behavior change.

### Tests
Extend `audit.illegal-transitions.spec.ts` with the two remaining illegal moves:
- A **branch manager cannot raw-rewrite an APPROVED audit's status** (the trigger blocks any BM raw status change — closes the un-approve vector).
- A **non-BM/non-admin cannot approve via `set_audit_approval`** (the assigned auditor is neither the assigned BM nor an admin).

**5/5 green.** The double-approval race guard was already covered by `audit.approval-flow.spec.ts`, so it wasn't duplicated.

### Docs
- `ARCHITECTURE.md §5`: the canonical **transition table** (from→to · who · sanctioned path · DB enforcement). The only sanctioned status-transition paths are `submit_audit` and `set_audit_approval`; raw client `status` writes are constrained by `enforce_audit_status_transition`.
- `ARCHITECTURE.md §7 (Storage)`: brought current with the 1a privatization (was still describing public buckets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)