### PR TITLE
fix(security): dev_mode production guardrail + config hygiene

### DIFF
--- a/apps/web/src/components/OrgConfigPanel.tsx
+++ b/apps/web/src/components/OrgConfigPanel.tsx
@@ -75,8 +75,8 @@ export const OrgConfigPanel: React.FC = () => {
         <div className="grid md:grid-cols-2 gap-4">
           <div className="card-section flex items-center justify-between">
             <div>
-              <p className="font-medium text-gray-900">Developer Mode</p>
-              <p className="text-sm text-gray-500">Allow debug helpers and relaxed validations for this org.</p>
+              <p className="font-medium text-gray-900">Developer Mode (org UI flag)</p>
+              <p className="text-sm text-gray-500">Org-level flag for debug helpers. Does not affect data access or RLS — the production database enforces dev-mode off regardless (see is_dev_mode guardrail).</p>
             </div>
             <Toggle checked={Boolean(config?.devMode)} onChange={(value) => toggleSetting('devMode', value)} disabled={mutation.isPending} />
           </div>

--- a/apps/web/tests/config.dev-mode-guardrail.spec.ts
+++ b/apps/web/tests/config.dev-mode-guardrail.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+import { getUserClient, getAnonClient } from './helpers/e2eSetup'
+
+// Phase 5 guardrail: dev_mode must be off on the production database, and it must
+// stay off even if the dev_mode flag is flipped, because app_config.environment is
+// 'production' and is_dev_mode() short-circuits on that. This protects against a
+// future policy re-introducing `is_dev_mode() OR ...` and accidentally disabling
+// RLS in production. The mutation half (dev_mode='true' still yields false) is
+// proven by a non-persisting rollback transaction in the migration; here we assert
+// the live invariant without mutating shared-DB global config.
+test.describe('dev_mode production guardrail', () => {
+  test('is_dev_mode() returns false on the production database', async () => {
+    const supa = await getUserClient('admin@trakr.com', 'Password@123')
+    const { data, error } = await supa.rpc('is_dev_mode')
+    expect(error, error?.message).toBeNull()
+    expect(data).toBe(false)
+  })
+
+  test('anon cannot execute is_dev_mode()', async () => {
+    const anon = getAnonClient()
+    test.skip(!anon, 'anon key not provided to e2e env')
+    const { error } = await anon!.rpc('is_dev_mode')
+    expect(error, 'anon EXECUTE on is_dev_mode must be revoked').toBeTruthy()
+  })
+})

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,6 +2,12 @@
 
 Running log of engineering decisions (newest first). One entry per decision: date, what, why.
 
+## 2026-07-22 — dev_mode production guardrail + config hygiene (Phase 5)
+- **Guardrail**: `is_dev_mode()` now returns false whenever `app_config.environment='production'`, regardless of the `dev_mode` flag; a prod migration sets `environment='production'` on the live DB. This is defense-in-depth — dev_mode is currently **latent** (no live policy references `is_dev_mode()`), but if a future policy re-introduces `is_dev_mode() OR …` it can no longer disable RLS in production. Proven via rollback-tx (prod+dev_mode=true → false; non-prod+dev_mode=true → true) and a live e2e assertion.
+- **Hygiene**: revoked anon EXECUTE on `is_dev_mode()` (no client caller); restricted `app_config` direct writes to `is_super_admin()` (org-scoped keys still flow through the super-admin `set_org_config` definer RPC, which bypasses the policy); added `org_id = current_user_org_id()` to `data_access_audit`'s INSERT WITH CHECK; and hardened `log_data_access` so a non-super caller can only log their own org (was trusting a caller-supplied `p_org_id`).
+- **OrgConfigPanel "Developer Mode" toggle**: it writes `org:<id>:dev_mode`, which `is_dev_mode()` never reads and which **nothing else in the client consumes** — a no-op. Relabeled honestly ("org UI flag … does not affect data access or RLS") rather than removing the toggle (a product decision).
+- **Deliberately skipped**: the client boot Sentry/banner alert (the DB guardrail is strictly stronger — dev_mode is force-false in prod, and `is_dev_mode()` has no client caller, so a boot check would always see false); the seed dev_mode default (superseded by the environment guardrail). **Action item for the user**: enable Auth "leaked password protection" in the Supabase dashboard (advisor `auth_leaked_password_protection`; dashboard-only, not migratable).
+
 ## 2026-07-22 — Photo durability: rollback + orphan cleanup + deprecated removal (Phase 4, safe parts)
 - **Scope decision**: did the hardening parts of Phase 4; the **offline capture outbox** (IndexedDB queue) was deferred — it's a new feature/abstraction (CLAUDE.md §4) and the lowest-priority, highest-effort item. So a photo captured while offline is still lost today; revisit if the pilot needs offline capture.
 - **Upload rollback**: `addSectionPhoto` now compensates a failed `audit_photos` insert with a best-effort `storage.remove` of the just-uploaded object, so a row failure no longer orphans the object.

--- a/supabase/migrations/20260722134615_devmode_prod_guardrail_and_config_hygiene.sql
+++ b/supabase/migrations/20260722134615_devmode_prod_guardrail_and_config_hygiene.sql
@@ -1,0 +1,61 @@
+-- Phase 5: dev_mode production guardrail + config hygiene (defense-in-depth).
+-- dev_mode is currently latent (no live policy references is_dev_mode()), but if a
+-- future policy re-introduces `is_dev_mode() OR ...`, it must not be able to disable
+-- RLS on the production database. Make production authoritative.
+
+-- 1. Harden is_dev_mode(): never true when app_config.environment='production',
+--    regardless of the dev_mode flag.
+CREATE OR REPLACE FUNCTION public.is_dev_mode()
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public' AS $$
+  select
+    not exists (select 1 from public.app_config where key='environment' and value='production')
+    and exists (select 1 from public.app_config where key='dev_mode' and value in ('true','1','on','t','yes'))
+$$;
+
+-- 2. Mark this database as production (only a prod migration sets this).
+INSERT INTO public.app_config(key, value) VALUES ('environment', 'production')
+  ON CONFLICT (key) DO UPDATE SET value = excluded.value;
+
+-- 3. is_dev_mode() has no client caller and must not be anon-callable. (Supabase
+--    default privileges grant anon EXECUTE explicitly, so revoke both.)
+REVOKE EXECUTE ON FUNCTION public.is_dev_mode() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.is_dev_mode() TO authenticated;
+
+-- 4. app_config holds global switches (dev_mode, environment). Restrict direct
+--    writes to super admins; org-scoped keys are written via the SECURITY DEFINER
+--    set_org_config RPC (already super-admin-gated), which bypasses these policies.
+ALTER POLICY app_config_admin_insert ON public.app_config WITH CHECK (public.is_super_admin());
+ALTER POLICY app_config_admin_update ON public.app_config USING (public.is_super_admin()) WITH CHECK (public.is_super_admin());
+ALTER POLICY app_config_admin_delete ON public.app_config USING (public.is_super_admin());
+
+-- 5. data_access_audit: a direct client insert must be for the caller's own org
+--    (defense-in-depth; the sanctioned writer is the definer RPC below).
+ALTER POLICY data_access_audit_insert ON public.data_access_audit
+  WITH CHECK ((select auth.uid()) = user_id AND org_id = public.current_user_org_id());
+
+-- 6. log_data_access: don't trust a caller-supplied org_id. A non-super caller can
+--    only log their own org; only a super admin may target another org.
+CREATE OR REPLACE FUNCTION public.log_data_access(p_org_id uuid, p_action text, p_reason text, p_export_scope jsonb)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $function$
+declare
+  v_user_id uuid;
+  v_org uuid := case when public.is_super_admin()
+                     then coalesce(p_org_id, public.current_user_org_id())
+                     else public.current_user_org_id() end;
+begin
+  select u.id into v_user_id
+  from public.users u
+  where u.auth_user_id = auth.uid() or u.id = auth.uid()
+  order by (u.auth_user_id = auth.uid()) desc
+  limit 1;
+
+  insert into public.data_access_audit (org_id, user_id, action, reason, export_scope)
+  values (
+    v_org,
+    v_user_id,
+    coalesce(nullif(p_action, ''), 'org_export'),
+    p_reason,
+    coalesce(p_export_scope, '{}'::jsonb)
+  );
+end;
+$function$;


### PR DESCRIPTION
## Phase 5 — dev_mode production guardrail + config hygiene (defense-in-depth)

`dev_mode` is **latent** today (no live policy references `is_dev_mode()`), but this hardens it so it can never disable RLS in production, plus tightens surrounding config surfaces.

### DB (migration `20260722134615`, applied live after rollback-tx proof)
- **`is_dev_mode()` returns false whenever `app_config.environment='production'`**, regardless of the `dev_mode` flag; a prod migration sets `environment='production'`. Even if a future policy re-adds `is_dev_mode() OR …`, it can't relax RLS in prod.
- **Revoke anon EXECUTE** on `is_dev_mode()` (no client caller).
- **Restrict `app_config` direct writes to `is_super_admin()`** — org-scoped keys still flow through the super-admin `set_org_config` definer RPC (bypasses the policy).
- **`data_access_audit` INSERT** now requires `org_id = current_user_org_id()`.
- **`log_data_access`** no longer trusts a caller-supplied `org_id` — a non-super caller can only log their own org.

### Client
- Relabel the OrgConfigPanel **"Developer Mode"** toggle: it writes `org:<id>:dev_mode`, which `is_dev_mode()` never reads and nothing else consumes (a no-op). Copy now states it doesn't affect data access/RLS.

### Proof
- Rollback-tx: prod+`dev_mode=true` → **false**; non-prod+`dev_mode=true` → true.
- `get_advisors`: `is_dev_mode` **cleared** from the anon-executable list; zero ERROR lints.
- New `config.dev-mode-guardrail` spec **2/2** (`is_dev_mode()`=false on prod + anon denied).

### Action item (dashboard-only, not migratable)
Enable Auth **leaked-password protection** in the Supabase dashboard (advisor `auth_leaked_password_protection`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)