### PR TITLE
docs: add Trakr domain invariants block to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,5 +39,16 @@ Whenever you execute a task, you inherently embody these three standards:
 - **No Silent Choices:** If uncertain about an approach, flag the options and trade-offs rather than making a silent choice.
 - **Zero Filler:** Output strictly code, terminal commands, and terse technical explanations. Do not apologize or use conversational filler.
 
+## 6. Trakr Domain Invariants (do not violate; verify before changing)
+
+These are load-bearing security/correctness rules a fresh session cannot infer from the code alone. Each names where it's enforced — check that enforcement still exists before you touch the area. Rationale and history are in `docs/memory.md`; the state machine and storage models are in `ARCHITECTURE.md` §5/§7.
+
+1. **`dev_mode` is false in production.** `is_dev_mode()` returns false whenever `app_config.environment='production'`, regardless of the flag. Never add `is_dev_mode() OR …` to an RLS policy expecting it to relax access in prod — it won't, by design.
+2. **Compliance scoring is weighted-only.** `calculateWeightedAuditScore()` in `@trakr/shared` is the canonical metric. N/A is excluded from the denominator; unanswered questions are excluded (completion is a separate metric). The unweighted/section-blended siblings are legacy — don't route new UI through them. Suspected-wrong semantics are flagged (see `scoring.test.ts` FLAGGED block), not silently changed.
+3. **Audit evidence is section-level only.** Never re-introduce per-question/comment photos (`Audit.photos`, `AuditPhoto.questionId`/`commentId` were removed). A CI grep-guard enforces this.
+4. **Audit status transitions go only through `submit_audit` / `set_audit_approval`.** Raw client `status` writes are constrained by the `enforce_audit_status_transition` trigger (auditor → {DRAFT,IN_PROGRESS,COMPLETED} only; decisions require the RPCs). Don't add a client path that writes `status` directly.
+5. **Storage buckets are private.** `audit-photos` and `profile-media` are private + org-path-scoped. Store the object **path**, never a public URL; render via `<SignedImage>` / `useSignedUrl` (signed at display time — the persisted query cache would stale a fetch-time signed URL). Never set a bucket public.
+6. **Every `SECURITY DEFINER` function org-checks the caller and pins `search_path`.** Mirror `create_audit_with_cycle_guard` / the `storage_*_in_my_org` helpers: `SET search_path TO 'public'`, authorize on org membership, allow the trusted backend via `auth.role()='service_role'` (never `is_admin_or_super()` alone — that's false for the service key), and `REVOKE EXECUTE … FROM PUBLIC, anon` on new public functions (Supabase default-grants anon explicitly).
+
 
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,6 +2,10 @@
 
 Running log of engineering decisions (newest first). One entry per decision: date, what, why.
 
+## 2026-07-22 — Invariants block + hardening plan complete (Phase 6)
+- Added a **Trakr Domain Invariants** section to `CLAUDE.md §6` codifying the six load-bearing rules this plan established (dev_mode false in prod; weighted-only scoring; section-level evidence; status transitions only via `submit_audit`/`set_audit_approval`; private storage + signed URLs; SECURITY DEFINER org-check + search_path + service_role allowance + anon revoke). Each names its enforcement point so a fresh session verifies before changing.
+- **Plan complete.** 9 PRs merged (#124 Phase 0, #125 1b, #126 1c, #127 Phase 2, #128 1a-1, #129 1a-2, #130 Phase 3, #131 Phase 4, #132 Phase 5). Both pilot-ending CRITICALs (audit self-approval, public storage) + the HIGH cross-org RPC vector closed and proven against the live DB. Deferred by choice: the offline photo-capture outbox (new feature); enabling Auth leaked-password protection (dashboard-only).
+
 ## 2026-07-22 — dev_mode production guardrail + config hygiene (Phase 5)
 - **Guardrail**: `is_dev_mode()` now returns false whenever `app_config.environment='production'`, regardless of the `dev_mode` flag; a prod migration sets `environment='production'` on the live DB. This is defense-in-depth — dev_mode is currently **latent** (no live policy references `is_dev_mode()`), but if a future policy re-introduces `is_dev_mode() OR …` it can no longer disable RLS in production. Proven via rollback-tx (prod+dev_mode=true → false; non-prod+dev_mode=true → true) and a live e2e assertion.
 - **Hygiene**: revoked anon EXECUTE on `is_dev_mode()` (no client caller); restricted `app_config` direct writes to `is_super_admin()` (org-scoped keys still flow through the super-admin `set_org_config` definer RPC, which bypasses the policy); added `org_id = current_user_org_id()` to `data_access_audit`'s INSERT WITH CHECK; and hardened `log_data_access` so a non-super caller can only log their own org (was trusting a caller-supplied `p_org_id`).


### PR DESCRIPTION
## Phase 6 (final) — invariants block

Codifies the six load-bearing security/correctness invariants this hardening plan established, so a future session can't unknowingly violate them. Each names its enforcement point (verify before changing); rationale/history live in `docs/memory.md`, models in `ARCHITECTURE.md`.

1. **dev_mode is false in production** (`is_dev_mode()` short-circuits on `environment='production'`).
2. **Compliance scoring is weighted-only** (`calculateWeightedAuditScore` canonical; N/A + unanswered excluded).
3. **Audit evidence is section-level only** (deprecated per-question photos removed + CI grep-guard).
4. **Status transitions only via `submit_audit`/`set_audit_approval`** (raw client `status` writes constrained by the trigger).
5. **Storage buckets are private** (store paths, render via signed URLs).
6. **Every SECURITY DEFINER fn org-checks + pins search_path** (+ service_role allowance, anon revoke).

Docs-only. This closes the plan — **9 PRs** (#124–#132).

🤖 Generated with [Claude Code](https://claude.com/claude-code)